### PR TITLE
WIP: Adding events (nearly there?)

### DIFF
--- a/seahorse_py/seahorse/prelude.py
+++ b/seahorse_py/seahorse/prelude.py
@@ -49,3 +49,6 @@ def instruction(function: Callable[..., None]) -> Callable[..., ProgramResult]:
 class Event:
     """An Anchor program event."""
     pass
+
+def emit(event: Event):
+    """Emit an event."""

--- a/seahorse_py/seahorse/prelude.py
+++ b/seahorse_py/seahorse/prelude.py
@@ -45,3 +45,7 @@ class Initializer(Generic[T]):
 
 def instruction(function: Callable[..., None]) -> Callable[..., ProgramResult]:
     """Turn a function into a program instruction."""
+
+class Event:
+    """An Anchor program event."""
+    pass

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -229,6 +229,7 @@ pub enum TyParam {
 pub enum TraitName {
     Enum,
     Account,
+    Event,
     Instruction,
 }
 
@@ -553,7 +554,7 @@ impl TraitName {
                 "key" => Some(Ty::function0(Ty::Pubkey)),
                 _ => None,
             },
-            Self::Enum | Self::Instruction => None,
+            Self::Enum | Self::Instruction | Self::Event => None,
         }
     }
 
@@ -637,6 +638,14 @@ impl TyDef {
     pub fn is_account(&self) -> bool {
         match self {
             TyDef::Struct { traits, .. } => traits.contains(&TraitName::Account),
+            _ => false,
+        }
+    }
+
+    /// Return whether this type def is an event.
+    pub fn is_event(&self) -> bool {
+        match self {
+            TyDef::Struct { traits, .. } => traits.contains(&TraitName::Event),
             _ => false,
         }
     }

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -205,6 +205,7 @@ pub enum Ty {
     TokenProgram,
     Rent,
     ProgramResult,
+    Event,
     Context(String),
     // Other types
     Defined(String),
@@ -301,6 +302,9 @@ pub enum Expression {
     },
     GetBump {
         name: String,
+    },
+    Emit {
+        event: Box<Expression>,
     },
     FString {
         format: String,

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -19,6 +19,11 @@ impl ToTokens for Def {
                 #[account]
                 #def
             },
+            Def::TyDef(def) if def.is_event() => quote! {
+                #[derive(Debug)]
+                #[event]
+                #def
+            },
             Def::TyDef(def) if def.is_enum() => quote! {
                 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq)]
                 #def

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -268,6 +268,7 @@ impl ToTokens for Ty {
             Ty::Empty(ty) => quote! { #ty },
             Ty::TokenAccount => quote! { token::TokenAccount },
             Ty::TokenMint => quote! { token::Mint },
+            Ty::Event => quote! { "" },
             Ty::ExactDefined {
                 name, is_acc: true, ..
             } => {
@@ -702,6 +703,9 @@ impl ToTokens for Expression {
             }
             Expression::GetBump { name } => quote! {
                 *ctx.bumps.get(#name).unwrap()
+            },
+            Expression::Emit { event } => quote! {
+                emit!(#event)
             },
             Expression::FString { format, args } => quote! {
                 format!(#format, #(#args),*)

--- a/src/core/to_seahorse_ast/from_python_ast.rs
+++ b/src/core/to_seahorse_ast/from_python_ast.rs
@@ -543,6 +543,7 @@ impl TryFrom<py::Expression> for TraitName {
             py::ExpressionType::Identifier { name } => match name.as_str() {
                 "Enum" => Ok(TraitName::Enum),
                 "Account" => Ok(TraitName::Account),
+                "Event" => Ok(TraitName::Event),
                 // Decorators
                 "instruction" => Ok(TraitName::Instruction), // TODO separate from trait types
                 name => Err(UnsupportedError::TraitNotRecognized(name.to_string())),

--- a/src/core/to_seahorse_ast/transform.rs
+++ b/src/core/to_seahorse_ast/transform.rs
@@ -200,7 +200,7 @@ impl TransformPass {
         match name.as_str() {
             "abs" | "pow" | "repr" | "sorted" | "str" | "sum" | "type" | "len" | "range"
             | "print" | "u8" | "u64" | "i64" | "f64" | "round" | "ceil" | "floor" | "min"
-            | "max" => {
+            | "max" | "emit" => {
                 return true;
             }
             _ => {}
@@ -330,6 +330,7 @@ impl TransformPass {
             Expression::SolTransfer { .. } => Ty::Unit,
             Expression::CpiCall { .. } => Ty::Unit,
             Expression::GetBump { .. } => Ty::U8,
+            Expression::Emit { .. } => Ty::Unit,
             Expression::FString { .. } => Ty::String,
             Expression::List(value) => {
                 if value.len() == 0 {
@@ -1198,6 +1199,13 @@ impl TransformPass {
                     let x = args.remove("x").unwrap();
 
                     Ok(x.with_call("abs", vec![]))
+                }
+                "emit" => {
+                    let mut args =
+                        self.transform_call_args(args, &vec![Param::new("e", Ty::Event)])?;
+
+                    let e = args.remove("e").unwrap();
+                    Ok(Expression::Emit { event: Box::new(e) })
                 }
                 "pow" => {
                     let mut args = self.transform_call_args(


### PR DESCRIPTION
This PR is an attempt to add support for Anchor events (#1)

The goal is to be able to support code like this:

```python
class PixelChanged(Event):
  pos_x: u8
  pos_y: u8
  col_r: u8
  col_g: u8
  col_b: u8

# then inside an instruction function
emit(PixelChanged(pos_x, pos_y, init_col_r, init_col_g, init_col_b))
```

### What I think I have working:

- Declaring an event (this is in the first commit). The class in the code above compiles to:
```
#[derive(Debug)]
#[event]
pub struct PixelChanged {
    pos_x: u8,
    pos_y: u8,
    col_r: u8,
    col_g: u8,
    col_b: u8,
}
```

- I think the `emit` transform is roughly wired up, but it doesn't work with Events yet. Specifically, if I change https://github.com/mcintyre94/seahorse-lang/blob/cm-add-events/src/core/to_seahorse_ast/transform.rs#L1205 to `self.transform_call_args(args, &vec![Param::new("e", Ty::U8)])?;`, ie make it expect a `U8` instead of an `Event`, I can get `emit(pos_x)` to compile to `emit!(pos_x)`. So I think most of the python -> seahorse AST -> rust wiring there is about right!

### What doesn't work yet:

When I compile the above code I get:

```
✗ Compiling pydraw...
Error: function not found.
61 |   emit(PixelChanged(pos_x, pos_y, init_col_r, init_col_g, init_col_b))
       ^
"PixelChanged" is not a function
```

So it seems my `Event` class is perhaps not being added to the list of valid classes? Or perhaps it is but that's not used to find out if it's a function name because we haven't needed class constructors before? 

After this something I haven't dealt with yet is figuring out how to convert the params to the Anchor output form:

```
emit!(PixelChanged {
  pos_x,
  pos_y,
  col_r: init_col_r,
  col_g: init_col_g,
  col_b: init_col_b,
});
```

I'm guessing this might be easier to achieve if we changed the Python to something like:

```
emit(PixelChanged({
  pos_x: pos_x,
  pos_y: pos_y,
  col_r: init_col_r,
  col_g: init_col_g,
  col_b: init_col_b
}))
```

But then I hit the error about dicts not being implemented yet, which is why I used the current format for now. 