### PR TITLE
Support array of U8 in seeds

### DIFF
--- a/src/core/to_seahorse_ast/transform.rs
+++ b/src/core/to_seahorse_ast/transform.rs
@@ -66,7 +66,7 @@ impl From<Error> for CoreError {
             Error::SeedsUnsupportedType(ty) => Self::make_raw(
                 "unsupported type for seed",
                 format!(
-                    "Hint: initializer/signer seeds may be other accounts, strings, and integers. Found: {}",
+                    "Hint: initializer/signer seeds may be other accounts, strings, integers and arrays of U8. Found: {}",
                     ty
                 )
             ),
@@ -1750,7 +1750,8 @@ impl TransformPass {
     ) -> Result<Vec<Expression>, CoreError> {
         let mut seeds = Vec::new();
         for seed in raw_seeds.into_iter() {
-            seeds.push(match self.infer_type(&seed) {
+            let ty = self.infer_type(&seed);
+            seeds.push(match ty {
                 Ty::String => seed
                     .with_call("as_bytes", vec![])
                     .with_call("as_ref", vec![]),
@@ -1767,6 +1768,12 @@ impl TransformPass {
                 ty if self.is_account_type(&ty) => {
                     seed.with_call("key", vec![]).with_call("as_ref", vec![])
                 }
+                Ty::Array(ref t, _) => match **t {
+                    Ty::U8 => seed.with_call("as_ref", vec![]),
+                    _ => {
+                        return Err(Error::SeedsUnsupportedType(ty).into_core());
+                    }
+                },
                 ty => {
                     return Err(Error::SeedsUnsupportedType(ty).into_core());
                 }


### PR DESCRIPTION
Anchor supports a (reference to an) array of `U8` values as a seed value. Using this allows the client-side code to be more straightforward than having each value as its own seed, since we can pack the array into a single buffer: `Buffer.from([x, y])`.

This PR adds support for this to Seahorse, such that this becomes valid:

```python
@instruction
def create_pixel(
  pixel: Empty[Pixel],
  user: Signer,
  pos_x: u8,
  pos_y: u8
):
  # Initialise pixel account
  pixel_account = pixel.init(
    payer = user,
    seeds = ["pixel", [pos_x, pos_y]]
  )
```

The generated accounts context has seeds:

```rust
#[derive(Accounts)]
# [instruction (pos_x : u8 , pos_y : u8)]
pub struct CreatePixel<'info> {
    #[account(
        init,
        payer = user,
        seeds = ["pixel".as_bytes().as_ref(), [pos_x, pos_y].as_ref()],
        bump,
        space = 8 + std::mem::size_of::<Pixel>()
    )]
    pub pixel: Box<Account<'info, Pixel>>,
    #[account(mut)]
    pub user: Signer<'info>,
    pub system_program: Program<'info, System>,
}
```

The PDA can then be generated in JS:

```js
const [pixelPublicKey] = web3.PublicKey.findProgramAddressSync(
  [Buffer.from("pixel"), Buffer.from([x, y])],
  program.programId,
)
```

From experimenting with Anchor I think only an array of U8 needs to be supported. A string/pubkey/longer number would take multiple bytes and then you'd have a nested list which Anchor doesn't seem to like. So I think it's only Array of U8 that should be supported. 

Closes #4 