### PR TITLE
Add support for generating #[event] structs

### DIFF
--- a/seahorse_py/seahorse/prelude.py
+++ b/seahorse_py/seahorse/prelude.py
@@ -45,3 +45,7 @@ class Initializer(Generic[T]):
 
 def instruction(function: Callable[..., None]) -> Callable[..., ProgramResult]:
     """Turn a function into a program instruction."""
+
+class Event:
+    """An Anchor program event."""
+    pass

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -229,6 +229,7 @@ pub enum TyParam {
 pub enum TraitName {
     Enum,
     Account,
+    Event,
     Instruction,
 }
 
@@ -553,7 +554,7 @@ impl TraitName {
                 "key" => Some(Ty::function0(Ty::Pubkey)),
                 _ => None,
             },
-            Self::Enum | Self::Instruction => None,
+            Self::Enum | Self::Instruction | Self::Event => None,
         }
     }
 
@@ -637,6 +638,14 @@ impl TyDef {
     pub fn is_account(&self) -> bool {
         match self {
             TyDef::Struct { traits, .. } => traits.contains(&TraitName::Account),
+            _ => false,
+        }
+    }
+
+    /// Return whether this type def is an event.
+    pub fn is_event(&self) -> bool {
+        match self {
+            TyDef::Struct { traits, .. } => traits.contains(&TraitName::Event),
             _ => false,
         }
     }

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -19,6 +19,11 @@ impl ToTokens for Def {
                 #[account]
                 #def
             },
+            Def::TyDef(def) if def.is_event() => quote! {
+                #[derive(Debug)]
+                #[event]
+                #def
+            },
             Def::TyDef(def) if def.is_enum() => quote! {
                 #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq)]
                 #def

--- a/src/core/to_seahorse_ast/from_python_ast.rs
+++ b/src/core/to_seahorse_ast/from_python_ast.rs
@@ -543,6 +543,7 @@ impl TryFrom<py::Expression> for TraitName {
             py::ExpressionType::Identifier { name } => match name.as_str() {
                 "Enum" => Ok(TraitName::Enum),
                 "Account" => Ok(TraitName::Account),
+                "Event" => Ok(TraitName::Event),
                 // Decorators
                 "instruction" => Ok(TraitName::Instruction), // TODO separate from trait types
                 name => Err(UnsupportedError::TraitNotRecognized(name.to_string())),


### PR DESCRIPTION
This PR adds support for generating Anchor event structs. They can't yet be emitted, which will be a bit fiddlier because we'll have to figure out Python class constructors. This is basically the easy bit of events! :) 

Example Python:

```
class PixelChanged(Event):
  pos_x: u8
  pos_y: u8
  col_r: u8
  col_g: u8
  col_b: u8
```

Generated Rust:

```
#[derive(Debug)]
#[event]
pub struct PixelChanged {
    pos_x: u8,
    pos_y: u8,
    col_r: u8,
    col_g: u8,
    col_b: u8,
}
```

Partially addresses #1 