### PR TITLE
Hide rust warning messages when compiling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "seahorse-lang"
 version = "0.1.6"
 edition = "2021"
-license = "MIT"
+license = "Apache-2.0"
 description = "Write Anchor-compatible Solana programs in Python"
 homepage = "https://seahorse-lang.org/"
 repository = "https://github.com/ameliatastic/seahorse-lang/"

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -880,6 +880,10 @@ pub fn from_seahorse_ast(ast: Program, program_name: String) -> Result<String, C
     let mut tokens = TokenStream::new();
 
     tokens.extend(quote! {
+        #![allow(unused_imports)]
+        #![allow(unused_variables)]
+        #![allow(unused_mut)]
+
         use anchor_lang::prelude::*;
         use anchor_spl::token;
         use anchor_spl::associated_token;


### PR DESCRIPTION
This PR hides warning messages of `unused_imports` `unused_variables` `unused_mut`.

If this solution is not appropriate, we could also add an optional argument about whether to hide rust warnings to `from_seahorse_ast` function.

After the changes, there are no more unnecessary warnings: 
![image](https://user-images.githubusercontent.com/98934430/185770389-96e8e4fa-1719-4706-bbd3-6ef46fe30a75.png)

Closes #12 
