### PR TITLE
Support defaults on enums + lists of an enum

### DIFF
--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -49,6 +49,7 @@ pub enum TyDef {
     Enum {
         name: String,
         options: Vec<String>,
+        default: Option<String>,
     },
 }
 
@@ -692,7 +693,7 @@ impl TyDef {
 
                 None
             }
-            Self::Enum { name, options } => {
+            Self::Enum { name, options, .. } => {
                 for option in options.iter() {
                     if option.as_str() == attr {
                         return Some(Ty::ExactDefined {

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -38,7 +38,7 @@ impl ToTokens for Def {
         tokens.extend(match self {
             Def::TyDef(def) if def.is_account() => account_token_stream(def),
             Def::TyDef(def) if def.is_enum() => quote! {
-                #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq)]
+                #[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq, Copy)]
                 #def
             },
             Def::TyDef(def) => quote! {
@@ -341,6 +341,11 @@ impl ToTokens for Ty {
                 quote! { Account<'_, #name> }
             }
             Ty::ExactDefined { name, .. } => {
+                let name = ident(&name);
+
+                quote! { #name }
+            }
+            Ty::Defined(name) => {
                 let name = ident(&name);
 
                 quote! { #name }

--- a/src/core/to_seahorse_ast/mod.rs
+++ b/src/core/to_seahorse_ast/mod.rs
@@ -2,7 +2,6 @@ mod from_python_ast;
 mod transform;
 
 use crate::core::{python_ast as py, seahorse_ast::*, CoreError};
-use from_python_ast::*;
 use transform::*;
 
 /// Convert a Python program into a Seahorse program

--- a/src/core/to_seahorse_ast/transform.rs
+++ b/src/core/to_seahorse_ast/transform.rs
@@ -1,9 +1,6 @@
 use crate::core::{python_ast::Location, seahorse_ast::*, CoreError};
 use heck::ToUpperCamelCase;
-use std::{
-    collections::{HashMap, HashSet},
-    mem::replace,
-};
+use std::{collections::HashMap, mem::replace};
 
 pub enum Error {
     NameReused(String),


### PR DESCRIPTION
This PR adds support for defaults to enums

- The Seahorse AST for enum is extended to support an optional default value
- For Python -> Seahorse AST, if an enum value is `0` then it is the default
- When converting Seahorse AST to Rust, if there is a default then we derive the `Default` attribute and include a `#[default]` on the appropriate enum value

Example Python:
```py
class Sign(Enum):
  X = "X"
  O = "O"
  Unset = 0
```

Outputs:
```rs
#[derive(AnchorSerialize, AnchorDeserialize, Debug, Clone, PartialEq, Copy, Default)]
pub enum Sign {
    X,
    O,
    #[default]
    Unset,
}
```

It also adds support for storing an array of enums, which in addition to deriving `Default` requires deriving `Copy` and implementing `to_tokens` for `Ty::Defined(name)`.

This allows compiling eg:
```py
class GameAccount(Account):
  board: Array[Array[Sign, 3], 3]
```

To output:
```rs
#[derive(Debug)]
#[account]
pub struct GameAccount {
    board: [[Sign; 3]; 3],
}
```

Caveat: Anchor doesn't seem to respect the derived default when initialising accounts. I've opened a bug here: https://github.com/coral-xyz/anchor/issues/2159

But these changes are still required for code that expects the `Default` attribute, like storing lists of enums (the second example currently won't compile). And our behaviour is equivalent to Anchor. 