### PR TITLE
Support creating accounts without seeds

### DIFF
--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -89,17 +89,17 @@ pub enum AccountInit {
     Program {
         account_type: Ty,
         payer: String,
-        seeds: Vec<Expression>,
+        seeds: Option<Vec<Expression>>,
     },
     TokenAccount {
         payer: String,
-        seeds: Vec<Expression>,
+        seeds: Option<Vec<Expression>>,
         mint: String,
         authority: String,
     },
     TokenMint {
         payer: String,
-        seeds: Vec<Expression>,
+        seeds: Option<Vec<Expression>>,
         decimals: u8,
         authority: String,
     },

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -172,9 +172,17 @@ impl ToTokens for AccountInit {
                     _ => panic!("Encountered an unexpected non-program account")
                 };
 
-                quote! {
-                    // #[account(init, payer = #payer, seeds = [#(#seeds),*], bump, space = 8 + std::mem::size_of::<#account_type>())]
-                    __SEAHORSE_INIT__: account![[[init, payer = #payer, seeds = [#(#seeds),*], bump, space = 8 + std::mem::size_of::<#account_type>()]]],
+                match seeds {
+                    Some(s) => 
+                        quote! {
+                            // #[account(init, payer = #payer, seeds = [#(#s),*], bump, space = 8 + std::mem::size_of::<#account_type>())]
+                            __SEAHORSE_INIT__: account![[[init, payer = #payer, seeds = [#(#s),*], bump, space = 8 + std::mem::size_of::<#account_type>()]]],
+                        },
+                    None => 
+                        quote! {
+                            // #[account(init, payer = #payer, space = 8 + std::mem::size_of::<#account_type>())]
+                            __SEAHORSE_INIT__: account![[[init, payer = #payer, space = 8 + std::mem::size_of::<#account_type>()]]],
+                        }
                 }
             }
             AccountInit::TokenAccount { payer, seeds, mint, authority } => {
@@ -182,8 +190,15 @@ impl ToTokens for AccountInit {
                 let mint = ident(mint);
                 let authority = ident(authority);
 
-                quote! {
-                    __SEAHORSE_INIT__: account![[[init, payer = #payer, seeds = [#(#seeds),*], bump, token::mint = #mint, token::authority = #authority]]],
+                match seeds {
+                    Some(s) => 
+                        quote! {
+                            __SEAHORSE_INIT__: account![[[init, payer = #payer, seeds = [#(#s),*], bump, token::mint = #mint, token::authority = #authority]]],
+                        },
+                    NONE => 
+                        quote! {
+                            __SEAHORSE_INIT__: account![[[init, payer = #payer, token::mint = #mint, token::authority = #authority]]],
+                        }
                 }
             },
             AccountInit::TokenMint { payer, seeds, decimals, authority } => {
@@ -191,8 +206,15 @@ impl ToTokens for AccountInit {
                 let decimals = Literal::u8_unsuffixed(*decimals);
                 let authority = ident(authority);
 
-                quote! {
-                    __SEAHORSE_INIT__: account![[[init, payer = #payer, seeds = [#(#seeds),*], bump, mint::decimals = #decimals, mint::authority = #authority]]],
+                match seeds {
+                    Some(s) =>
+                        quote! {
+                            __SEAHORSE_INIT__: account![[[init, payer = #payer, seeds = [#(#s),*], bump, mint::decimals = #decimals, mint::authority = #authority]]],
+                        },
+                    None =>
+                        quote! {
+                            __SEAHORSE_INIT__: account![[[init, payer = #payer, mint::decimals = #decimals, mint::authority = #authority]]],
+                        }
                 }
             },
             AccountInit::AssociatedTokenAccount { payer, mint, authority } => {

--- a/src/core/to_seahorse_ast/transform.rs
+++ b/src/core/to_seahorse_ast/transform.rs
@@ -1622,7 +1622,8 @@ impl TransformPass {
                                         Param::new(
                                             "seeds",
                                             Ty::Array(Box::new(Ty::Any), TyParam::Any),
-                                        ),
+                                        )
+                                        .optional(),
                                         Param::new("mint", Ty::TokenMint),
                                         Param::new("authority", Ty::Any),
                                     ],
@@ -1630,8 +1631,9 @@ impl TransformPass {
                                 let mut arg = move |name: &str| args.remove(name).unwrap();
 
                                 let payer = arg("payer").as_id().unwrap();
-                                let seeds =
-                                    self.transform_seeds(arg("seeds").as_list().unwrap())?;
+                                let seeds = arg("seeds")
+                                    .as_list()
+                                    .map(|s| self.transform_seeds(s).unwrap());
                                 let mint = arg("mint").as_id().unwrap();
                                 let authority = arg("authority").as_id().unwrap();
 
@@ -1653,7 +1655,8 @@ impl TransformPass {
                                         Param::new(
                                             "seeds",
                                             Ty::Array(Box::new(Ty::Any), TyParam::Any),
-                                        ),
+                                        )
+                                        .optional(),
                                         Param::new("decimals", Ty::U8),
                                         Param::new("authority", Ty::Any),
                                     ],
@@ -1661,8 +1664,9 @@ impl TransformPass {
                                 let mut arg = move |name: &str| args.remove(name).unwrap();
 
                                 let payer = arg("payer").as_id().unwrap();
-                                let seeds =
-                                    self.transform_seeds(arg("seeds").as_list().unwrap())?;
+                                let seeds = arg("seeds")
+                                    .as_list()
+                                    .map(|s| self.transform_seeds(s).unwrap());
                                 let decimals = arg("decimals").as_int().unwrap();
                                 let authority = arg("authority").as_id().unwrap();
 
@@ -1711,15 +1715,15 @@ impl TransformPass {
                                         Param::new(
                                             "seeds",
                                             Ty::Array(Box::new(Ty::Any), TyParam::Any),
-                                        ),
+                                        )
+                                        .optional(),
                                     ],
                                 )?;
-                                let mut arg = move |name: &str| args.remove(name).unwrap();
+                                let mut arg = move |name: &str| args.remove(name);
 
-                                let payer = arg("payer").as_id().unwrap();
-                                let seeds =
-                                    self.transform_seeds(arg("seeds").as_list().unwrap())?;
-
+                                let payer = arg("payer").unwrap().as_id().unwrap();
+                                let seeds = arg("seeds")
+                                    .map(|s| self.transform_seeds(s.as_list().unwrap()).unwrap());
                                 AccountInit::Program {
                                     account_type: Ty::ExactDefined {
                                         name: acc,


### PR DESCRIPTION
This PR makes the `seeds` optional on the various `AccountInit` types. This means that we can initialize accounts without seeds. This is useful for accounts that don't need to be a PDA, since we can just generate a random keypair each time we create one instead of finding a unique seed unnecessarily.

When seeds are passed the behaviour is unchanged

With this PR we can compile eg:
```py
from seahorse.prelude import *

declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')

class GameAccount(Account):
  data: u64

@instruction
def init(game_account: Empty[GameAccount], user: Signer):
  game_account.init(payer = user)
```

To:
```rs
use anchor_lang::prelude::*;
use anchor_lang::solana_program;
use anchor_spl::associated_token;
use anchor_spl::token;
use std::convert::TryFrom;

declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");

#[derive(Debug)]
#[account]
pub struct GameAccount {
    data: u64,
}

pub fn init_handler(mut ctx: Context<Init>) -> Result<()> {
    let mut game_account = &mut ctx.accounts.game_account;
    let mut user = &mut ctx.accounts.user;

    Ok(())
}

#[derive(Accounts)]
pub struct Init<'info> {
    #[account(
        init,
        payer = user,
        space = 8 + std::mem::size_of::<GameAccount>()
    )]
    pub game_account: Box<Account<'info, GameAccount>>,
    #[account(mut)]
    pub user: Signer<'info>,
    pub system_program: Program<'info, System>,
}

#[program]
pub mod enum_test {
    use super::*;

    pub fn init(ctx: Context<Init>) -> Result<()> {
        init_handler(ctx)
    }
}
```

The `game_account` can then be initialized to any public key.

Closes #8 