### PR TITLE
Add support for strings 🧵

### DIFF
--- a/data/seahorse_prelude.py
+++ b/data/seahorse_prelude.py
@@ -226,6 +226,26 @@ class Enum:
     ```
     """
 
+class String([N]):
+    """A fixed-length unicode string of size N characters
+
+    This is used instead of `str`, so that it can be used on fields of accounts.
+    If an account contains a string of length N, then we need to add N to its size when we initialize it.
+    Note that this will include 4 bytes per character on the account.
+
+    Example:
+    ```
+    class MyString(Account):
+        the_string: String[20]
+
+    @instruction
+    def init_data(owner: Signer, my_string: Empty[MyString], initial_string: String[20]):
+        data = my_string.init(payer = owner)
+        data.the_string = initial_string
+    ```
+    """
+
+
 # ============
 # Solana types
 # ============

--- a/data/seahorse_prelude.py
+++ b/data/seahorse_prelude.py
@@ -231,7 +231,9 @@ class String([N]):
 
     This is used instead of `str`, so that it can be used on fields of accounts.
     If an account contains a string of length N, then we need to add N to its size when we initialize it.
-    Note that this will include 4 bytes per character on the account.
+
+    Note that this will include 4 bytes per character on the account. You may prefer to use StringBytes[N]
+    instead if this is not appropriate.
 
     Example:
     ```
@@ -240,6 +242,25 @@ class String([N]):
 
     @instruction
     def init_data(owner: Signer, my_string: Empty[MyString], initial_string: String[20]):
+        data = my_string.init(payer = owner)
+        data.the_string = initial_string
+    ```
+    """
+
+class StringBytes([N]):
+    """A fixed-length string of size N bytes
+
+    This is used instead of `str`, so that it can be used on fields of accounts.
+    If an account contains a string of length N bytes, then we need to add N bytes to its size when we initialize it.
+
+    Example:
+
+    ```
+    class MyString(Account):
+        the_string: StringBytes[20]
+
+    @instruction
+    def init_data(owner: Signer, my_string: Empty[MyString], initial_string: StringBytes[20]):
         data = my_string.init(payer = owner)
         data.the_string = initial_string
     ```

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -196,7 +196,7 @@ pub enum Ty {
     Tuple(Vec<Ty>),
     List(Box<Ty>),
     Array(Box<Ty>, TyParam),
-    StringLength(TyParam),
+    StringOfLength(TyParam),
     Iter(Box<Ty>),
     Function {
         params: Vec<Param>,
@@ -331,7 +331,7 @@ pub enum Expression {
     RawFString {
         values: Vec<Expression>,
     },
-    StringLength(Box<Expression>)
+    StringLength(Box<Expression>),
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -507,7 +507,9 @@ impl Ty {
             }
             (Self::AssociatedTokenAccount, Self::TokenAccount) => true,
             (self_, Self::Union(opts)) => opts.iter().any(|opt| self_.fits_as(opt)),
-            (Self::StringLength(p_self), Self::StringLength(p_other)) => p_self.fits_as(p_other),
+            (Self::StringOfLength(p_self), Self::StringOfLength(p_other)) => {
+                p_self.fits_as(p_other)
+            }
             (_, Self::Any) => true,
             _ => self == other,
         }

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -195,6 +195,7 @@ pub enum Ty {
     Tuple(Vec<Ty>),
     List(Box<Ty>),
     Array(Box<Ty>, TyParam),
+    StringLength(TyParam),
     Iter(Box<Ty>),
     Function {
         params: Vec<Param>,
@@ -584,6 +585,14 @@ impl Expression {
     pub fn as_list(self) -> Option<Vec<Expression>> {
         match self {
             Expression::List(value) => Some(value),
+            _ => None,
+        }
+    }
+
+    pub fn as_tuple1(self) -> Option<Self> {
+        println!("{:?}", self);
+        match self {
+            Expression::Tuple(mut value) if value.len() == 1 => Some(value.remove(0)),
             _ => None,
         }
     }

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -197,6 +197,7 @@ pub enum Ty {
     List(Box<Ty>),
     Array(Box<Ty>, TyParam),
     StringOfLength(TyParam),
+    StringOfBytes(TyParam),
     Iter(Box<Ty>),
     Function {
         params: Vec<Param>,
@@ -510,6 +511,7 @@ impl Ty {
             (Self::StringOfLength(p_self), Self::StringOfLength(p_other)) => {
                 p_self.fits_as(p_other)
             }
+            (Self::StringOfBytes(p_self), Self::StringOfBytes(p_other)) => p_self.fits_as(p_other),
             (_, Self::Any) => true,
             _ => self == other,
         }

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -331,6 +331,7 @@ pub enum Expression {
     RawFString {
         values: Vec<Expression>,
     },
+    StringLength(Box<Expression>)
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -506,6 +507,7 @@ impl Ty {
             }
             (Self::AssociatedTokenAccount, Self::TokenAccount) => true,
             (self_, Self::Union(opts)) => opts.iter().any(|opt| self_.fits_as(opt)),
+            (Self::StringLength(p_self), Self::StringLength(p_other)) => p_self.fits_as(p_other),
             (_, Self::Any) => true,
             _ => self == other,
         }

--- a/src/core/seahorse_ast.rs
+++ b/src/core/seahorse_ast.rs
@@ -90,6 +90,7 @@ pub enum AccountInit {
         account_type: Ty,
         payer: String,
         seeds: Option<Vec<Expression>>,
+        strings_size: usize,
     },
     TokenAccount {
         payer: String,

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -804,6 +804,9 @@ impl ToTokens for Expression {
 
                 quote! { #name }
             }
+            Expression::StringLength(value) => quote! {
+                #value.chars().count()
+            },
             Expression::RawCall { .. } | Expression::RawFString { .. } => {
                 panic!("Encountered an unformattable expression")
             }

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -307,6 +307,7 @@ impl ToTokens for Ty {
                 quote! { [#ty; #len] }
             }
             Ty::StringOfLength(_) => quote! { String },
+            Ty::StringOfBytes(_) => quote! { String },
             Ty::Pubkey => quote! { Pubkey },
             Ty::DefinedName(name) => {
                 let name = ident(&name);

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -306,7 +306,7 @@ impl ToTokens for Ty {
 
                 quote! { [#ty; #len] }
             }
-            Ty::StringLength(_) => quote! { String },
+            Ty::StringOfLength(_) => quote! { String },
             Ty::Pubkey => quote! { Pubkey },
             Ty::DefinedName(name) => {
                 let name = ident(&name);

--- a/src/core/to_rust_source.rs
+++ b/src/core/to_rust_source.rs
@@ -305,6 +305,7 @@ impl ToTokens for Ty {
 
                 quote! { [#ty; #len] }
             }
+            Ty::StringLength(_) => quote! { String },
             Ty::Pubkey => quote! { Pubkey },
             Ty::DefinedName(name) => {
                 let name = ident(&name);

--- a/src/core/to_seahorse_ast/from_python_ast.rs
+++ b/src/core/to_seahorse_ast/from_python_ast.rs
@@ -23,6 +23,7 @@ pub enum UnsupportedError {
     TypeNotRecognized,
     ListType,
     ArrayTypeNotRecognized,
+    StringTypeNotRecognized,
     TraitNotRecognized(String),
     TraitNotIdentifier,
     Await,
@@ -287,6 +288,10 @@ impl From<UnsupportedError> for CoreError {
                 "arbitrary top-level statements are not supported",
                 "Hint: if you're trying to write the body of your smart contract, you need to put it inside of an instruction:\n\n    @instruction\n    def instruction_name(arg: Type, account: AccountType, ...):\n        ..."
             ),
+            UnsupportedError::StringTypeNotRecognized => Self::make_raw(
+                "unsupported string type hint",
+                "Hint: string types have the following form: String[N] where N is an integer literal"
+            ),
         }
     }
 }
@@ -526,6 +531,10 @@ impl TryFrom<Expression> for Ty {
                             TyParam::Exact(len as usize),
                         )),
                         _ => Err(UnsupportedError::ArrayTypeNotRecognized),
+                    },
+                    "String" => match index.as_int() {
+                        Some(len) => Ok(Self::StringLength(TyParam::Exact(len as usize))),
+                        _ => Err(UnsupportedError::StringTypeNotRecognized),
                     },
                     _ => Err(UnsupportedError::TypeNotRecognized),
                 },

--- a/src/core/to_seahorse_ast/from_python_ast.rs
+++ b/src/core/to_seahorse_ast/from_python_ast.rs
@@ -24,6 +24,7 @@ pub enum UnsupportedError {
     ListType,
     ArrayTypeNotRecognized,
     StringTypeNotRecognized,
+    StringBytesTypeNotRecognized,
     TraitNotRecognized(String),
     TraitNotIdentifier,
     Await,
@@ -292,6 +293,10 @@ impl From<UnsupportedError> for CoreError {
                 "unsupported string type hint",
                 "Hint: string types have the following form: String[N] where N is an integer literal"
             ),
+            UnsupportedError::StringBytesTypeNotRecognized => Self::make_raw(
+                "unsupported StringBytes type hint",
+                "Hint: StringByte types have the following form: StringBytes[N] where N is an integer literal"
+            ),
         }
     }
 }
@@ -535,6 +540,10 @@ impl TryFrom<Expression> for Ty {
                     "String" => match index.as_int() {
                         Some(len) => Ok(Self::StringOfLength(TyParam::Exact(len as usize))),
                         _ => Err(UnsupportedError::StringTypeNotRecognized),
+                    },
+                    "StringBytes" => match index.as_int() {
+                        Some(len) => Ok(Self::StringOfBytes(TyParam::Exact(len as usize))),
+                        _ => Err(UnsupportedError::StringTypeNotRecognized), // TODO
                     },
                     _ => Err(UnsupportedError::TypeNotRecognized),
                 },

--- a/src/core/to_seahorse_ast/from_python_ast.rs
+++ b/src/core/to_seahorse_ast/from_python_ast.rs
@@ -533,7 +533,7 @@ impl TryFrom<Expression> for Ty {
                         _ => Err(UnsupportedError::ArrayTypeNotRecognized),
                     },
                     "String" => match index.as_int() {
-                        Some(len) => Ok(Self::StringLength(TyParam::Exact(len as usize))),
+                        Some(len) => Ok(Self::StringOfLength(TyParam::Exact(len as usize))),
                         _ => Err(UnsupportedError::StringTypeNotRecognized),
                     },
                     _ => Err(UnsupportedError::TypeNotRecognized),

--- a/src/core/to_seahorse_ast/transform.rs
+++ b/src/core/to_seahorse_ast/transform.rs
@@ -1113,7 +1113,7 @@ impl TransformPass {
                             Ty::Union(vec![
                                 // Ty::List(Box::new(Ty::Any)),
                                 Ty::Array(Box::new(Ty::Any), TyParam::Any),
-                                Ty::StringLength(TyParam::Any),
+                                Ty::StringOfLength(TyParam::Any),
                             ]),
                         )],
                     )?;
@@ -1128,7 +1128,7 @@ impl TransformPass {
                         Ty::Array(_, TyParam::Exact(len)) => Ok(Expression::Int(len as i64)),
                         // Note that we want string length to be computed dynamically at run-time,
                         // so we don't just return the max length here
-                        Ty::StringLength(_) => Ok(Expression::StringLength(Box::new(param))),
+                        Ty::StringOfLength(_) => Ok(Expression::StringLength(Box::new(param))),
                         _ => panic!("Unexpected type?"),
                     }
                 }
@@ -1731,7 +1731,7 @@ impl TransformPass {
                                                 and subtract (num * std::mem::size_of::<String>) in to_rust_source
                                                 For now I think it's not worth adding that complexity though
                                                 */
-                                                Ty::StringLength(TyParam::Exact(len)) => {
+                                                Ty::StringOfLength(TyParam::Exact(len)) => {
                                                     acc + 4 + (len * 4)
                                                 }
                                                 _ => acc,

--- a/src/core/to_seahorse_ast/transform.rs
+++ b/src/core/to_seahorse_ast/transform.rs
@@ -1114,6 +1114,7 @@ impl TransformPass {
                                 // Ty::List(Box::new(Ty::Any)),
                                 Ty::Array(Box::new(Ty::Any), TyParam::Any),
                                 Ty::StringOfLength(TyParam::Any),
+                                Ty::StringOfBytes(TyParam::Any),
                             ]),
                         )],
                     )?;
@@ -1129,6 +1130,7 @@ impl TransformPass {
                         // Note that we want string length to be computed dynamically at run-time,
                         // so we don't just return the max length here
                         Ty::StringOfLength(_) => Ok(Expression::StringLength(Box::new(param))),
+                        Ty::StringOfBytes(_) => Ok(Expression::StringLength(Box::new(param))),
                         _ => panic!("Unexpected type?"),
                     }
                 }
@@ -1733,6 +1735,13 @@ impl TransformPass {
                                                 */
                                                 Ty::StringOfLength(TyParam::Exact(len)) => {
                                                     acc + 4 + (len * 4)
+                                                }
+                                                /*
+                                                Here we just add the 4-byte vec prefix to the stated size in bytes
+                                                The above note about over-estimation applies the same here
+                                                */
+                                                Ty::StringOfBytes(TyParam::Exact(bytes)) => {
+                                                    acc + 4 + bytes
                                                 }
                                                 _ => acc,
                                             });


### PR DESCRIPTION
This PR adds support for strings! The end result is that we can now compile code such as:
```py
class Tweet(Account):
  owner: Pubkey
  tweet: String[280]

@instruction
def new_tweet(author: Signer, tweet_account: Empty[Tweet], tweet: String[280]):
  tweet_account.init(payer=author, seeds = ['tweet', author])
  tweet_account.owner = author.key()

  assert len(tweet) <= 280, "Tweet must be no more than 280 characters"
  tweet_account.tweet = tweet
```

This involves the following changes:

- A new `String[N]` type is added to the compiler. In the seahorse AST this is stored as `Ty::StringOfLength(len)`, so Seahorse always knows the maximum length of a string. In the generated Rust it is simply a `String`
- When we initialize a new account, we add the length of any `StringOfLength(n)` fields on it to the size. This is necessary because Rust doesn't know the length of strings and `std::mem::size_of::<String>` is a small constant
- The new `String[N]`type is added to the prelude
- Python's `len` function is updated to support strings. This works slightly differently to the existing implementation for arrays, which returns the defined length. For strings we generate Rust code that computes the actual length, eg. `tweet.chars().count()`. This means that you can assert on the length of a string as in the example above

I've also updated the way we put string constants in Rust to add the `.to_string()` so you can also write `tweet_account.tweet = "hello world"` and it'll compile to `tweet_account.tweet = "hello world!".to_string();`

Also note that this will slightly over-estimate the space required for the string. I've added a comment, but because we're already doing `std::mem::size_of::<Account>` this includes a small number of bytes (24 in Rust playground) for the String. I'm not subtracting this from the number I calculate because I'm not sure how constant it is. 