### PR TITLE
Fix v2 error in examples/calculator.py

### DIFF
--- a/examples/calculator.py
+++ b/examples/calculator.py
@@ -41,4 +41,4 @@ def do_operation(owner: Signer, calculator: Calculator, op: Operation, num: i64)
   elif op == Operation.MUL:
     calculator.display *= num
   elif op == Operation.DIV:
-    calculator.display /= num
+    calculator.display //= num


### PR DESCRIPTION
As-is this example errors with:

Error: type mismatch - expected an instance of f64, found an instance of i64.
44 |     calculator.display /= num

The docs are updated to use `//=` instead, and with that change it compiles correctly