### PR TITLE
Allow compiling to WASM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Fixed
+
 - Removed some of the unnecessary `borrow()`s from appearing in seed lists.
+
+### Added
+
+- Support for compiling to WASM
 
 ## [0.2.0] - 2022-10-05

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,9 @@ owo-colors = "3.4.0"
 proc-macro2 = "1.0.40"
 quote = "1.0.20"
 regex = "1.5.6"
-rustfmt-wrapper = "0.2.0"
 rustpython-parser = "0.1.2"
 spinners = "4.1.0"
 toml_edit = "0.14.4"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rustfmt-wrapper = "0.2.0"


### PR DESCRIPTION
- Make rustfmt-wrapper a conditional dependency, exclude for wasm
- Conditionally exclude code that uses rustfmt when compiling for wasm

Pretty much the same as what I did before, except the `beautify` function makes it a bit cleaner!

Should make no change for non-wasm targets, while allowing `cargo build --target wasm32-unknown-unknown` to work again!

Closes #20 