### PR TITLE
Class methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,5 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for compiling to WASM
+- Allow non-enum classes to define methods, including static methods
+- Allow non-account classes to define constructors
 
 ## [0.2.0] - 2022-10-05

--- a/src/core/clean/ast.rs
+++ b/src/core/clean/ast.rs
@@ -51,7 +51,7 @@ pub enum ClassDefStatementObj {
         ty: Option<TyExpression>,
         value: Option<Expression>,
     },
-    // MethodDef(FunctionDef)
+    MethodDef(FunctionDef),
 }
 
 /// A function definition.
@@ -69,7 +69,7 @@ pub struct FunctionDef {
 /// Parameters for a function definition.
 #[derive(Clone, Debug)]
 pub struct Params {
-    // Leaving this open for later when more Pythonic support is added
+    pub is_instance_method: bool,
     pub params: Vec<Param>,
 }
 

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use super::check::Ty;
+use super::{check::Ty, builtin::prelude::MethodType};
 use crate::core::Tree;
 use std::collections::HashMap;
 
@@ -45,6 +45,8 @@ pub enum TypeDef {
 pub struct Struct {
     pub name: String,
     pub fields: Vec<(String, TyExpr)>,
+    pub methods: Vec<(MethodType, Function)>,
+    pub constructor: Option<Function>,
 }
 
 /// An Anchor account definition.

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -55,6 +55,7 @@ pub struct Account {
     pub name: String,
     // Save type info for generation later
     pub fields: Vec<(String, TyExpr, Ty)>,
+    pub methods: Vec<(MethodType, Function)>,
 }
 
 /// An `enum` definition.

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -1007,8 +1007,8 @@ impl TryFrom<CheckOutput> for BuildOutput {
                             match item {
                                 Item::Builtin(..) => {}
                                 Item::Defined(defined) => {
-                                    let context = contexts.remove(&name).unwrap();
-                                    let signature = signatures.remove(&name).unwrap();
+                                    let mut context = contexts.remove(&name).unwrap();
+                                    let mut signature = signatures.remove(&name).unwrap();
 
                                     match defined {
                                         Located(
@@ -1021,41 +1021,70 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                         ) => match signature {
                                             Signature::Class(ClassSignature::Struct(
                                                 StructSignature {
-                                                    is_account, mut fields, ..
+                                                    is_account, fields: mut fields_map, methods: mut methods_map, ..
                                                 },
                                             )) => {
                                                 let type_def = if is_account {
                                                     let account = Account {
                                                         name: name.clone(),
-                                                        fields: body.into_iter().map(|statement| match statement.1 {
+                                                        fields: body.into_iter().filter_map(|statement| match statement.1 {
                                                             ast::ClassDefStatementObj::FieldDef { name, ty: Some(ty_expr), .. } => {
-                                                                let ty = fields.remove(&name).unwrap();
-                                                                (
+                                                                let ty = fields_map.remove(&name).unwrap();
+                                                                Some((
                                                                     name,
                                                                     make_ty_expr(ty_expr, ty.clone()),
                                                                     ty
-                                                                )
+                                                                ))
                                                             },
-                                                            _ => panic!()
+                                                            _ => None
                                                         })
                                                         .collect()
                                                     };
 
                                                     TypeDef::Account(account)
                                                 } else {
-                                                    TypeDef::Struct(Struct {
-                                                        name,
-                                                        fields: body.into_iter().map(|statement| match statement.1 {
+                                                    let mut fields = vec![];
+                                                    let mut methods = vec![];
+                                                    let mut constructor = None;
+
+                                                    for Located(_, statement) in body.into_iter() {
+                                                        match statement {
                                                             ast::ClassDefStatementObj::FieldDef { name, ty: Some(ty_expr), .. } => {
-                                                                let ty = fields.remove(&name).unwrap();
-                                                                (
+                                                                let ty = fields_map.remove(&name).unwrap();
+                                                                fields.push((
                                                                     name,
                                                                     make_ty_expr(ty_expr, ty),
-                                                                )
+                                                                ));
                                                             },
-                                                            _ => panic!()
-                                                        })
-                                                        .collect()
+                                                            ast::ClassDefStatementObj::MethodDef(func) => {
+                                                                let typecheck = match1!(context, FinalContext::Class(ref mut typechecks) => typechecks.remove(&func.name).unwrap());
+
+                                                                let mut context = Context {
+                                                                    check_output: &check_output,
+                                                                    abs: &path,
+                                                                    ix_context: None,
+                                                                    directives: None,
+                                                                    expr_order: typecheck.expr_order.into(),
+                                                                    assign_order: typecheck.assign_order.into(),
+                                                                };
+                                                                let (method_type, signature) = methods_map.remove(&func.name).unwrap();
+                                                                let func = context.build_func(func, signature)?;
+
+                                                                if &func.name == "__init__" {
+                                                                    constructor = Some(func);
+                                                                } else {
+                                                                    methods.push((method_type, func));
+                                                                }
+                                                            },
+                                                            _ => {}
+                                                        }
+                                                    }
+
+                                                    TypeDef::Struct(Struct {
+                                                        name,
+                                                        fields,
+                                                        methods,
+                                                        constructor
                                                     })
                                                 };
 

--- a/src/core/compile/builtin/python.rs
+++ b/src/core/compile/builtin/python.rs
@@ -576,7 +576,7 @@ impl BuiltinSource for Python {
                             let value = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
 
                             expr.obj = ExpressionObj::Rendered(quote! {
-                                #value.push(#(#args),*)
+                                #value.borrow_mut().push(#(#args),*)
                             });
 
                             Ok(Transformed::Expression(expr))

--- a/src/core/compile/builtin/python.rs
+++ b/src/core/compile/builtin/python.rs
@@ -592,7 +592,12 @@ impl BuiltinSource for Python {
                     Ty::Transformed(
                         Ty::Anonymous(0).into(),
                         Transformation::new(|mut expr| {
-                            expr.obj = expr.obj.with_call("unwrap", vec![]);
+                            let function = match1!(expr.obj, ExpressionObj::Call { function, .. } => *function);
+                            let value = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
+
+                            expr.obj = ExpressionObj::Rendered(quote! {
+                                #value.borrow_mut().pop().unwrap()
+                            });
 
                             Ok(Transformed::Expression(expr))
                         }),

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -2,14 +2,21 @@
 // yet
 use crate::core::{
     clean::ast as ca,
-    compile::{builtin as bi, namespace::*},
+    compile::{
+        ast::ExpressionObj,
+        build::{Transformation, Transformed},
+        builtin as bi,
+        namespace::*,
+    },
     util::*,
 };
+use crate::match1;
 // LOL I JUST LEARNED THAT I COULD DO THIS INSTEAD OF IMPORTING FROM CRATE
 use super::{
     builtin::{Builtin, BuiltinSource},
     check::{DefinedType, ParamType, Ty, TyName},
 };
+use quote::quote;
 use std::collections::HashMap;
 
 enum Error {
@@ -17,6 +24,8 @@ enum Error {
     EnumAccount,
     InvalidEnumVariant,
     InvalidClassField,
+    InvalidClassConstructor,
+    AccountConstructor,
 }
 
 impl Error {
@@ -35,6 +44,14 @@ impl Error {
                 "invalid class field",
                 "Help: make sure your field has nothing but a type annotation:\n\n    field_name: Type"
             ),
+            Self::InvalidClassConstructor => CoreError::make_raw(
+                "invalid class constructor",
+                "Help: class constructors (__init__ methods) must be instance methods (have a self parameter), and must return nothing."
+            ),
+            Self::AccountConstructor => CoreError::make_raw(
+                "accounts may not have constructors",
+                "Help: new accounts may only be created with a call to Empty.init()."
+            )
         }
         .located(loc.clone())
     }
@@ -73,8 +90,41 @@ pub struct StructSignature {
     pub is_account: bool,
     pub bases: Vec<Ty>,
     pub fields: HashMap<String, Ty>,
-    // methods: HashMap<String, Ty>,
-    // TODO special methods like constructor?
+    pub methods: HashMap<String, (MethodType, FunctionSignature)>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum MethodType {
+    Instance,
+    Static,
+}
+
+impl StructSignature {
+    pub fn constructor(&self, name: TyName) -> Option<Box<Ty>> {
+        let func = self.methods.get("__init__");
+
+        return func.as_ref().map(
+            |(_, FunctionSignature { params, returns })| {
+                Ty::Function(
+                    params.clone(),
+                    // Need to transform Python's constructor syntax: `Class(...args)`
+                    // to our Rust constructor syntax: `Class::__new__(...args)`
+                    Ty::Transformed(
+                        Ty::Generic(name, vec![]).into(),
+                        Transformation::new(|mut expr| {
+                            let (class, args) = match1!(expr.obj, ExpressionObj::Call { function, args } => (function, args));
+
+                            expr.obj = ExpressionObj::Rendered(quote! {
+                                #class::__new__(#(#args),*)
+                            });
+
+                            Ok(Transformed::Expression(expr))
+                        })
+                    ).into()
+                ).into()
+            }
+        );
+    }
 }
 
 /// Signature for a class that gets treated as an enum.
@@ -164,6 +214,7 @@ impl TryFrom<NamespaceOutput> for SignOutput {
                             is_account,
                             bases,
                             fields,
+                            methods,
                         })) => Signature::Class(ClassSignature::Struct(StructSignature {
                             is_account,
                             bases,
@@ -171,6 +222,7 @@ impl TryFrom<NamespaceOutput> for SignOutput {
                                 .into_iter()
                                 .map(|(name, ty)| (name, raw_tree.correct(ty)))
                                 .collect(),
+                            methods,
                         })),
                         Signature::Function(FunctionSignature { params, returns }) => {
                             Signature::Function(FunctionSignature {
@@ -250,6 +302,9 @@ fn build_signature(
 
                             variants.insert(name.clone(), ());
                         }
+                        _ => {
+                            todo!();
+                        }
                     }
                 }
 
@@ -258,6 +313,8 @@ fn build_signature(
                 })))
             } else {
                 let mut fields = HashMap::new();
+                let mut methods = HashMap::new();
+
                 for statement in body.iter() {
                     let Located(loc, obj) = statement;
 
@@ -269,6 +326,30 @@ fn build_signature(
 
                             fields.insert(name.clone(), root.build_ty(&ty.as_ref().unwrap(), abs)?);
                         }
+                        ca::ClassDefStatementObj::MethodDef(ca::FunctionDef {
+                            name,
+                            params,
+                            returns,
+                            ..
+                        }) => {
+                            if params.is_instance_method {
+                                methods.insert(
+                                    name.clone(),
+                                    (
+                                        MethodType::Instance,
+                                        build_function_signature(params, returns, abs, root)?,
+                                    ),
+                                );
+                            } else {
+                                methods.insert(
+                                    name.clone(),
+                                    (
+                                        MethodType::Static,
+                                        build_function_signature(params, returns, abs, root)?,
+                                    ),
+                                );
+                            }
+                        }
                     }
                 }
 
@@ -276,6 +357,7 @@ fn build_signature(
                     is_account,
                     fields,
                     bases: bases_,
+                    methods,
                 })))
             }
         }
@@ -284,29 +366,38 @@ fn build_signature(
             // decorator_list,
             returns,
             ..
-        }) => {
-            let params = params
-                .params
-                .iter()
-                .map(|Located(_, ca::ParamObj { arg, annotation })| {
-                    let ty = root.build_ty(annotation, abs)?;
-                    Ok((arg.clone(), ty, ParamType::Required))
-                })
-                .collect::<CResult<Vec<_>>>()?;
-
-            let returns = returns
-                .as_ref()
-                .map(|ty| root.build_ty(ty, abs))
-                .unwrap_or(Ok(Ty::Generic(
-                    TyName::Builtin(bi::python::Python::None.into()),
-                    vec![],
-                )))?;
-
-            Ok(Signature::Function(FunctionSignature { params, returns }))
-        }
+        }) => Ok(Signature::Function(build_function_signature(
+            params, returns, abs, root,
+        )?)),
         _ => panic!(),
     }
     .map_err(|err: Error| err.core(loc))
+}
+
+fn build_function_signature(
+    params: &ca::Params,
+    returns: &Option<ca::TyExpression>,
+    abs: &Vec<String>,
+    root: &Tree<Namespace>,
+) -> CResult<FunctionSignature> {
+    let params = params
+        .params
+        .iter()
+        .map(|Located(_, ca::ParamObj { arg, annotation })| {
+            let ty = root.build_ty(annotation, abs)?;
+            Ok((arg.clone(), ty, ParamType::Required))
+        })
+        .collect::<CResult<Vec<_>>>()?;
+
+    let returns = returns
+        .as_ref()
+        .map(|ty| root.build_ty(ty, abs))
+        .unwrap_or(Ok(Ty::Generic(
+            TyName::Builtin(bi::python::Python::None.into()),
+            vec![],
+        )))?;
+
+    return Ok(FunctionSignature { params, returns });
 }
 
 pub fn sign(registry: NamespaceOutput) -> Result<SignOutput, CoreError> {

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -198,7 +198,7 @@ impl ToTokens for Struct {
         };
 
         tokens.extend(quote! {
-            #[derive(Clone, Debug, Default, AnchorSerialize, AnchorDeserialize)]
+            #[derive(Clone, Debug, Default)]
             pub struct #name { #(#fields),* }
 
             #instance_impl
@@ -1212,6 +1212,13 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
                 }
             }
 
+            impl <T: Default> Default for Mutable<T> {
+                fn default() -> Self {
+                    Self::new(T::default())
+                }
+            }
+
+            // Pythonic indexing for vec/array types (Seahorse List, Array types)
             impl<T: Clone> Mutable<Vec<T>> {
                 pub fn wrapped_index(&self, mut index: i128) -> usize {
                     if index > 0 {
@@ -1223,7 +1230,6 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
                 }
             }
 
-            // TODO const generics allowed here?
             impl<T: Clone, const N: usize> Mutable<[T; N]> {
                 pub fn wrapped_index(&self, mut index: i128) -> usize {
                     if index > 0 {


### PR DESCRIPTION
Adds methods (instance and static) for struct-type classes (a.k.a., non-enums). Accounts may not define constructors, since Solana needs to know they exist instead of just existing transiently in memory.

Example usage:

```py
class Point:
    x: i32
    y: i32

    # Constructor defined like in Python
    # Caveat: structs now derive `Default`, and have all of their fields set to
    # their default values
    def __init__(self, x: i32, y: i32):
        self.x = x
        self.y = y

    # Giving a method a `self` parameter makes it an instance method
    def manhattan_dist(self) -> i32:
        return self.x + self.y

    # No self = static method - no @staticmethod needed
    def origin() -> Point:
        return Point(0, 0)

# ...

@instruction
def ix(...):
    p = Point(2, 3)
    q = Point.origin()

    print(p.manhattan_dist(), q.manhattan_dist())
```