### PR TITLE
Implement default and copy on enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow storing arrays of enums on an account
+
 ## [0.2.2]
 
 ### Fixed

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -917,7 +917,7 @@ impl<'a> Context<'a> {
                     }
                 }
                 Signature::Class(ClassSignature::Enum(EnumSignature { variants })) => {
-                    if variants.contains_key(attr) {
+                    if variants.iter().any(|(name, _)| name == attr) {
                         Some((
                             Ty::Anonymous(0),
                             Ty::Generic(TyName::Defined(path.clone(), DefinedType::Enum), vec![]),

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -130,7 +130,7 @@ impl StructSignature {
 /// Signature for a class that gets treated as an enum.
 #[derive(Clone, Debug)]
 pub struct EnumSignature {
-    pub variants: HashMap<String, ()>,
+    pub variants: Vec<(String, ())>,
 }
 
 /// Signature for a function.
@@ -290,7 +290,7 @@ fn build_signature(
             }
 
             if is_enum {
-                let mut variants = HashMap::new();
+                let mut variants = vec![];
                 for statement in body.iter() {
                     let Located(loc, obj) = statement;
 
@@ -300,7 +300,7 @@ fn build_signature(
                                 return Err(Error::InvalidEnumVariant.core(loc));
                             }
 
-                            variants.insert(name.clone(), ());
+                            variants.push((name.clone(), ()));
                         }
                         _ => {
                             todo!();

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -336,16 +336,25 @@ impl ToTokens for Enum {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         let Self { name, variants } = self;
         let name = ident(name);
-        let variants = variants.iter().map(|(name, _)| {
+        let variants_tokens = variants.iter().map(|(name, _)| {
             let name = ident(name);
 
             quote! { #name }
         });
 
+        let (first_variant, _) = &variants[0];
+        let first_variant = ident(first_variant);
+
         tokens.extend(quote! {
-            #[derive(Clone, Debug, PartialEq, AnchorSerialize, AnchorDeserialize)]
+            #[derive(Clone, Debug, PartialEq, AnchorSerialize, AnchorDeserialize, Copy)]
             pub enum #name {
-                #(#variants),*
+                #(#variants_tokens),*
+            }
+
+            impl Default for #name {
+                fn default() -> Self {
+                    #name::#first_variant
+                }
             }
         });
     }


### PR DESCRIPTION
This PR implements `Default` and `Copy` for enums, which means that they can now be stored in an array on an account. Code like this now compiles:

```
from seahorse.prelude import *

declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')

class Sign(Enum):
  Unset = 0
  X = "X"
  O = "O"

class GameAccount(Account):
  board: Array[Sign, 3]
```

The first variant in the enum becomes the default, so when a `GameAccount` is initialized `board` is an array of `Unset`.

Notes:

- While we need to implement `Default` for the compiler, Anchor itself won't use it when initializing the account - it'll always use the first variant. See https://github.com/coral-xyz/anchor/issues/2159. So if we ever provide some way to customise the default, we'll need to adjust the variant orders too to keep Anchor in sync. For now though it's just the first variant, same as anchor.
- I decided not to derive `Default` and use the new `#[default]` macro like my earlier PR did, instead writing an `impl Default` block. The earlier PR required a feature flag on Playground, the compiler feature has only been available in recent Rust versions. Not sure if we document a required Rust version but I don't think that feature is worth potentially forcing an update on users/potentially showing a confusing Rust error message.
- Enums now retain order when compiled, internally using a `Vec` instead of `HashMap`
- Nested lists don't currently work. `Array[Array[Sign, 3], 3]` will compile to `Mutable<[Mutable<[Sign; 3]>; 3]>` and `Mutable` is missing some traits (like Copy) which are non-trivial/maybe not possible to implement. Possibly related to "Nested mutable types in accounts" ticket in the Project?

Closes #25 