### PR TITLE
Change len(str) to be char count, add size(str) for string size in bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow storing arrays of enums on an account
+- New `size` function that returns the size of a string (for now) in bytes
+
+### Changed
+
+- `len(str)` now has the same behaviour as Python, and returns character count. This may be different to the size in bytes
 
 ## [0.2.2]
 

--- a/data/seahorse_prelude.py
+++ b/data/seahorse_prelude.py
@@ -837,3 +837,11 @@ def int_bytes(n: Any, be: bool = False) -> List[u8]:
     @param n: The integer you wish to convert to bytes.
     @param be: Whether you want the conversion to be big-endian - defaults to false.
     """
+
+def size(ob: str) -> u64:
+    """
+    Get the size of an object in bytes.
+    Currently this is only supported for strings.
+    
+    @param ob: The object to get the size of.
+    """

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -287,16 +287,16 @@ impl BuiltinSource for Prelude {
             // size(str) -> u64
             Self::Size => Ty::new_function(
                 vec![
-                    ("s", Ty::python(Python::Str, vec![]), ParamType::Required)
+                    ("ob", Ty::python(Python::Str, vec![]), ParamType::Required)
                 ],
                 Ty::Transformed(
                     Ty::prelude(Self::RustInt(false, 64), vec![]).into(),
                     Transformation::new(|mut expr| {
                         let args = match1!(expr.obj, ExpressionObj::Call { args, .. } => args);
-                        let s = args.into_iter().next().unwrap();
+                        let ob = args.into_iter().next().unwrap();
 
                         expr.obj = ExpressionObj::As {
-                            value: ExpressionObj::Rendered(quote! { #s.len() }).into(),
+                            value: ExpressionObj::Rendered(quote! { #ob.len() }).into(),
                             ty: TyExpr::new_specific(vec!["u64"], Mutability::Immutable)
                         };
 

--- a/src/core/compile/builtin/python.rs
+++ b/src/core/compile/builtin/python.rs
@@ -745,7 +745,7 @@ impl BuiltinSource for Python {
                             let string = expr.obj;
 
                             expr.obj = ExpressionObj::Rendered(quote! {
-                                (#string.len() as u64)
+                                (#string.chars().count() as u64)
                             });
 
                             Ok(Transformed::Expression(expr))


### PR DESCRIPTION
- Changes the behaviour of `len(str)` to match Python and return a character count. Eg `len("ƒoo")` is 3. This is a change from the current behaviour which uses Rust's `str.len()` and would return 4.

- Adds a new function `size(str)` which gets the size in bytes of a string. This uses Rust's `str.len()`.

This is intended to be a step toward supporting strings on accounts by allowing custom account sizing. Code like `assert len(content) < 280, "tweet is too long!"` will now behave the same as in Python, allowing up to 280 unicode characters. Asserting on size is also possible if required.

And the extra space would be defined as `4 + size(content)` when we have that capability.

I split this into a separate PR because it's a breaking change of `len`. 