### PR TITLE
Add support for customising account size using space/padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Allow storing arrays of enums on an account
+- Allow setting `space` or `padding` on account init to customise account size
 
 ## [0.2.2]
 

--- a/data/seahorse_prelude.py
+++ b/data/seahorse_prelude.py
@@ -691,7 +691,7 @@ class Signer(AccountWithKey):
 class Empty(Generic[T]):
     """An account that needs to be initialized."""
 
-    def init(self, payer: Signer, seeds: List[Any] = None, mint: 'TokenMint' = None, decimals: u8 = None, authority: AccountWithKey = None, associated: bool = False, space: u64 = None)  -> T:
+    def init(self, payer: Signer, seeds: List[Any] = None, mint: 'TokenMint' = None, decimals: u8 = None, authority: AccountWithKey = None, associated: bool = False, space: u64 = None, padding: u64 = None)  -> T:
         """
         Initialize the account.
         
@@ -702,6 +702,7 @@ class Empty(Generic[T]):
         @param authority: If initializing a TokenAccount/TokenMint, this is the account that has authority over the account.
         @param associated: If initializing an associated token account, must be set to true.
         @param space: If initializing a program account, you can use this to overwrite Seahorse's calculation of the account size.
+        @param padding: If initializing a program account, you can use this to add extra space to Seahorse's calculation of the account size.
         @returns: The new, initialized account. All of the data in this account will be set to 0, bytewise.
         """
 

--- a/data/seahorse_prelude.py
+++ b/data/seahorse_prelude.py
@@ -691,7 +691,7 @@ class Signer(AccountWithKey):
 class Empty(Generic[T]):
     """An account that needs to be initialized."""
 
-    def init(self, payer: Signer, seeds: List[Any] = None, mint: 'TokenMint' = None, decimals: u8 = None, authority: AccountWithKey = None, associated: bool = False) -> T:
+    def init(self, payer: Signer, seeds: List[Any] = None, mint: 'TokenMint' = None, decimals: u8 = None, authority: AccountWithKey = None, associated: bool = False, space: u64 = None)  -> T:
         """
         Initialize the account.
         
@@ -701,6 +701,7 @@ class Empty(Generic[T]):
         @param decimals: If initializing a TokenMint, this is the number of decimals the new token has.
         @param authority: If initializing a TokenAccount/TokenMint, this is the account that has authority over the account.
         @param associated: If initializing an associated token account, must be set to true.
+        @param space: If initializing a program account, you can use this to overwrite Seahorse's calculation of the account size.
         @returns: The new, initialized account. All of the data in this account will be set to 0, bytewise.
         """
 

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -178,6 +178,7 @@ pub struct AccountAnnotation {
     pub mint_authority: Option<TypedExpression>,
     pub token_mint: Option<TypedExpression>,
     pub token_authority: Option<TypedExpression>,
+    pub space: Option<TypedExpression>,
 }
 
 impl AccountAnnotation {
@@ -192,6 +193,7 @@ impl AccountAnnotation {
             mint_authority: None,
             token_mint: None,
             token_authority: None,
+            space: None,
         }
     }
 }

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -179,6 +179,7 @@ pub struct AccountAnnotation {
     pub token_mint: Option<TypedExpression>,
     pub token_authority: Option<TypedExpression>,
     pub space: Option<TypedExpression>,
+    pub padding: Option<TypedExpression>,
 }
 
 impl AccountAnnotation {
@@ -194,6 +195,7 @@ impl AccountAnnotation {
             token_mint: None,
             token_authority: None,
             space: None,
+            padding: None,
         }
     }
 }

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -407,6 +407,11 @@ impl BuiltinSource for Prelude {
                             Ty::python(Python::Bool, vec![]),
                             ParamType::Optional,
                         ),
+                        (
+                            "space",
+                            Ty::prelude(Self::RustInt(false, 64), vec![]),
+                            ParamType::Optional,
+                        ),
                     ],
                     Ty::Transformed(
                         Ty::Anonymous(0).into(),
@@ -438,6 +443,7 @@ impl BuiltinSource for Prelude {
                                     ));
                                 }
                             };
+                            let space = args.next().unwrap().optional();
 
                             annotation.payer = Some(payer);
                             annotation.seeds = seeds.map(|seeds| {
@@ -460,12 +466,16 @@ impl BuiltinSource for Prelude {
                                                 "Hint: you can only pass in a payer and optionally a list of seeds."
                                             ));
                                         }
+
+                                        annotation.space = space;
                                     }
+                                    // TODO: when we add padding make sure they're not both set
                                     TyName::Builtin(Builtin::Prelude(Self::TokenMint)) => {
                                         if mint.is_some()
                                             || authority.is_none()
                                             || decimals.is_none()
                                             || associated.is_some()
+                                            || space.is_some()
                                         {
                                             return Err(CoreError::make_raw(
                                                 "invalid argument to Empty[TokenMint].init()",
@@ -480,6 +490,7 @@ impl BuiltinSource for Prelude {
                                         if mint.is_none()
                                             || authority.is_none()
                                             || decimals.is_some()
+                                            || space.is_some()
                                         {
                                             return Err(CoreError::make_raw(
                                                 "invalid argument to Empty[TokenAccount].init()",

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -412,6 +412,11 @@ impl BuiltinSource for Prelude {
                             Ty::prelude(Self::RustInt(false, 64), vec![]),
                             ParamType::Optional,
                         ),
+                        (
+                            "padding",
+                            Ty::prelude(Self::RustInt(false, 64), vec![]),
+                            ParamType::Optional,
+                        ),
                     ],
                     Ty::Transformed(
                         Ty::Anonymous(0).into(),
@@ -444,6 +449,7 @@ impl BuiltinSource for Prelude {
                                 }
                             };
                             let space = args.next().unwrap().optional();
+                            let padding = args.next().unwrap().optional();
 
                             annotation.payer = Some(payer);
                             annotation.seeds = seeds.map(|seeds| {
@@ -467,9 +473,17 @@ impl BuiltinSource for Prelude {
                                             ));
                                         }
 
+                                        if space.is_some() && padding.is_some() {
+                                            return Err(CoreError::make_raw(
+                                                "invalid argument to Empty.init() for a program account",
+                                                "Hint: you can only pass one of space and padding",
+                                            ));
+                                        }
+
                                         annotation.space = space;
+                                        annotation.padding = padding;
                                     }
-                                    // TODO: when we add padding make sure they're not both set
+
                                     TyName::Builtin(Builtin::Prelude(Self::TokenMint)) => {
                                         if mint.is_some()
                                             || authority.is_none()

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -620,6 +620,7 @@ impl<'a> ToTokens for AccountAnnotationWithTyExpr<'a> {
                 token_authority,
                 mint_decimals,
                 mint_authority,
+                space,
             },
             ty_expr,
         ) = self;
@@ -635,9 +636,12 @@ impl<'a> ToTokens for AccountAnnotationWithTyExpr<'a> {
             if let AccountTyExpr::Defined(name) = &**ty_expr {
                 let ty_expr = StaticPath(name);
 
-                params.push(Some(
-                    quote! { init, space = std::mem::size_of::<#ty_expr>() + 8 },
-                ));
+                let space = match space {
+                    Some(s) => quote! { #s as usize },
+                    None => quote! { std::mem::size_of::<#ty_expr>() + 8 },
+                };
+
+                params.push(Some(quote! { init, space = #space }));
             } else {
                 params.push(Some(quote! { init }));
             }


### PR DESCRIPTION
This PR allows customising the space set for a newly initialised account. 

Currently it's hardcoded to `std::mem::size_of::<type>() + 8`, which is usually correct but doesn't work when storing a vector like a string or a list on an account.

This PR adds two new params to the `Empty.init` function that allow modifying the account size:

- `space` can be used to completely overwrite the account size. If you know you want 500 bytes, `space=500` will set it to that.
- `padding` can be used to add extra space to an account. For example `padding=44` will add an extra 44 bytes to the calculated account size.

Both are optional, they can only be used for program accounts and they're mutually exclusive.

In combination with #32 (and other v2 features!) we can write code like this:

```py
class Tweet(Account):
  author: Pubkey
  content: str

  def size() -> u64:
    return 1000

@instruction
def write_tweet(
  tweet: Empty[Tweet],
  author: Signer,
  content: str
):
  tweet = tweet.init(payer = author, space = Tweet.size())
  tweet.author = author.key()
  tweet.content = content
```

And this:
```py
class Tweet(Account):
  author: Pubkey
  content: str

@instruction
def write_tweet(
  tweet: Empty[Tweet],
  author: Signer,
  content: str
):
  tweet = tweet.init(payer = author, padding = 4 + size(content))
  tweet.author = author.key()
  tweet.content = content
```

Closes #11