### PR TITLE
Add support for Anchor events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow storing arrays of enums on an account
 - New `size` function that returns the size of a string (for now) in bytes
 - Allow setting `space` or `padding` on account init to customise account size
+- Support for Anchor events
 
 ### Changed
 

--- a/data/seahorse_prelude.py
+++ b/data/seahorse_prelude.py
@@ -677,6 +677,14 @@ class Account(AccountWithKey):
         @param amount: The amount (in lamports, not SOL) to transfer.
         """
 
+class Event:
+    """Anchor event that clients can listen for"""
+
+    def emit(self):
+        """
+        Emit the event to the blockchain
+        """
+
 class Signer(AccountWithKey):
     """Instruction signer."""
 

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -47,6 +47,7 @@ pub struct Struct {
     pub fields: Vec<(String, TyExpr)>,
     pub methods: Vec<(MethodType, Function)>,
     pub constructor: Option<Function>,
+    pub is_event: bool,
 }
 
 /// An Anchor account definition.

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -209,7 +209,7 @@ fn make_ty_expr(ty_expr: ast::TyExpression, ty: Ty) -> TyExpr {
                         params,
                     },
                 },
-                TyName::Defined(_, DefinedType::Struct | DefinedType::Enum) => TyExpr::Generic {
+                TyName::Defined(_, DefinedType::Struct | DefinedType::Enum | DefinedType::Event) => TyExpr::Generic {
                     mutability,
                     name: base,
                     params,
@@ -1021,7 +1021,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                         ) => match signature {
                                             Signature::Class(ClassSignature::Struct(
                                                 StructSignature {
-                                                    is_account, fields: mut fields_map, methods: mut methods_map, ..
+                                                    is_account, is_event, fields: mut fields_map, methods: mut methods_map, ..
                                                 },
                                             )) => {
                                                 let mut fields = vec![];
@@ -1073,7 +1073,8 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                                         name,
                                                         fields: fields.into_iter().map(|(name, ty, _)| (name, ty)).collect(),
                                                         methods,
-                                                        constructor
+                                                        constructor,
+                                                        is_event,
                                                     })
                                                 };
 

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -15,6 +15,7 @@ pub enum Prelude {
     Array,
     Enum,
     Account,
+    Event,
     Signer,
     Empty,
     Program,
@@ -46,6 +47,7 @@ pub fn namespace() -> Namespace {
     let data = [
         ("Array", Prelude::Array),
         ("Enum", Prelude::Enum),
+        ("Event", Prelude::Event),
         ("Account", Prelude::Account),
         ("Signer", Prelude::Signer),
         ("Empty", Prelude::Empty),
@@ -93,6 +95,7 @@ impl BuiltinSource for Prelude {
             Self::Array => "Array",
             Self::Enum => "Enum",
             Self::Account => "Account",
+            Self::Event => "Event",
             Self::Signer => "Signer",
             Self::Empty => "Empty",
             Self::Program => "Program",

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -343,6 +343,7 @@ pub enum DefinedType {
     Struct,
     Account,
     Enum,
+    Event,
 }
 
 impl std::fmt::Display for TyName {
@@ -734,6 +735,7 @@ impl<'a> Context<'a> {
             Ty::Generic(t, _) => match t {
                 TyName::Builtin(x) => x.attr(attr),
                 TyName::Defined(path, DefinedType::Struct | DefinedType::Enum) => self.defined_attr(&path, attr),
+                TyName::Defined(path, DefinedType::Event) => self.defined_attr(&path, attr),
                 TyName::Defined(path, DefinedType::Account) => self.defined_attr(&path, attr).or_else(|| {
                     match attr.as_str() {
                         "key" => Some((
@@ -790,10 +792,7 @@ impl<'a> Context<'a> {
             },
             Ty::Type(t, _) => match t {
                 TyName::Builtin(x) => x.static_attr(attr).map(|t| (Ty::Anonymous(0), t)),
-                TyName::Defined(path, DefinedType::Struct | DefinedType::Enum) => self.defined_static_attr(&path, attr),
-                TyName::Defined(path, DefinedType::Account) => {
-                    self.defined_static_attr(&path, attr)
-                }
+                TyName::Defined(path, DefinedType::Struct | DefinedType::Enum | DefinedType::Account | DefinedType::Event) => self.defined_static_attr(&path, attr),
             },
             Ty::Path(mut abs) => match self.sign_output.namespace_output.tree.get(&abs) {
                 Some(Tree::Leaf(namespace)) => match namespace.get(attr) {

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -155,6 +155,10 @@ impl Tree<Signed> {
                                 is_account: true,
                                 ..
                             })) => DefinedType::Account,
+                            Signature::Class(ClassSignature::Struct(StructSignature {
+                                is_event: true,
+                                ..
+                            })) => DefinedType::Event,
                             Signature::Class(ClassSignature::Enum(..)) => DefinedType::Enum,
                             _ => DefinedType::Struct,
                         };

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -88,6 +88,7 @@ pub enum ClassSignature {
 #[derive(Clone, Debug)]
 pub struct StructSignature {
     pub is_account: bool,
+    pub is_event: bool,
     pub bases: Vec<Ty>,
     pub fields: HashMap<String, Ty>,
     pub methods: HashMap<String, (MethodType, FunctionSignature)>,
@@ -212,11 +213,13 @@ impl TryFrom<NamespaceOutput> for SignOutput {
                     match signature {
                         Signature::Class(ClassSignature::Struct(StructSignature {
                             is_account,
+                            is_event,
                             bases,
                             fields,
                             methods,
                         })) => Signature::Class(ClassSignature::Struct(StructSignature {
                             is_account,
+                            is_event,
                             bases,
                             fields: fields
                                 .into_iter()
@@ -262,6 +265,7 @@ fn build_signature(
         ca::TopLevelStatementObj::ClassDef { body, bases, .. } => {
             let mut is_account = false;
             let mut is_enum = false;
+            let mut is_event = false;
             let mut bases_ = vec![];
             for base in bases.iter() {
                 let base = root.build_ty(base, abs)?;
@@ -278,6 +282,12 @@ fn build_signature(
                         _,
                     ) => {
                         is_enum = true;
+                    }
+                    Ty::Generic(
+                        TyName::Builtin(bi::Builtin::Prelude(bi::prelude::Prelude::Event)),
+                        _
+                    ) => {
+                        is_event = true;
                     }
                     ty => {
                         return Err(Error::InvalidBase(ty).core(&loc));
@@ -368,6 +378,7 @@ fn build_signature(
 
                 Ok(Signature::Class(ClassSignature::Struct(StructSignature {
                     is_account,
+                    is_event,
                     fields,
                     bases: bases_,
                     methods,

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -128,6 +128,7 @@ impl ToTokens for Struct {
             fields,
             methods,
             constructor,
+            is_event,
         } = self;
         let name = ident(name);
         let fields = fields.iter().map(|(name, ty)| {
@@ -197,8 +198,15 @@ impl ToTokens for Struct {
             None
         };
 
-        tokens.extend(quote! {
+        let macros = if *is_event { quote! {
             #[derive(Clone, Debug, Default)]
+        }} else { quote! {
+            #[event]
+            #[derive(Clone, Debug, Default)]
+        }};
+
+        tokens.extend(quote! {
+            #macros
             pub struct #name { #(#fields),* }
 
             #instance_impl

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -131,11 +131,6 @@ impl ToTokens for Struct {
             is_event,
         } = self;
         let name = ident(name);
-        let fields = fields.iter().map(|(name, ty)| {
-            let name = ident(name);
-
-            quote! { pub #name: #ty }
-        });
 
         let mut instance_methods = vec![];
         let mut static_methods = vec![];
@@ -186,8 +181,27 @@ impl ToTokens for Struct {
         // belong to an `impl Mutable<Class>` block, and the static methods will belong to an
         // `impl Class` block.
 
-        let instance_impl = if instance_methods.len() > 0 {
-            Some(quote! { impl Mutable<#name> { #(#instance_methods)* } })
+        let event_emit_fn = if *is_event {
+            let fs = fields.iter().map(|(name, _)| {
+                let name = ident(name);
+                quote! { #name: self.borrow().#name }
+            });
+
+            Some(quote! {
+                fn __emit__(&self) {
+                    emit!(#name { #(#fs),* })
+                }
+            })
+        } else {
+            None
+        };
+
+        let instance_impl = if instance_methods.len() > 0 || event_emit_fn.is_some() {
+            Some(quote! { impl Mutable<#name> {
+                #(#instance_methods)*
+
+                #event_emit_fn
+            }})
         } else {
             None
         };
@@ -199,11 +213,17 @@ impl ToTokens for Struct {
         };
 
         let macros = if *is_event { quote! {
-            #[derive(Clone, Debug, Default)]
-        }} else { quote! {
             #[event]
             #[derive(Clone, Debug, Default)]
+        }} else { quote! {
+            #[derive(Clone, Debug, Default)]
         }};
+
+        let fields = fields.iter().map(|(name, ty)| {
+            let name = ident(name);
+
+            quote! { pub #name: #ty }
+        });
 
         tokens.extend(quote! {
             #macros


### PR DESCRIPTION
This PR adds support for Anchor events. It enables code like:

```py
class XEvent(Event):
    x: u8 
    y: u8 

    def __init__(self, x: u8, y: u8):
        self.x = x
        self.y = y

  @instruction
  def init(payer: Signer, x: u8, y: u8):
      e = XEvent(x, y)
      e.x = 100
      e.emit()
```

I iterated a bit on this (see branch name lol), but settled on using a new `DefinedType::Event` for events, but then compiling them to a `StructSignature` (like accounts do) rather than their own `ClassSignature` (like enums).

They compile almost identically to plain structs. The differences are:

- A `#[event]` macro
- A generated `__emit__` function in their `impl Mutable` block. This looks like eg:
```rs
fn __emit__(&self) {
    emit!(XEvent {
        x: self.borrow().x,
        y: self.borrow().y
    })
}
```

See Discord where this approach was originally suggested: https://discordapp.com/channels/1005658120548270224/1033829665493745694/1034555100871524393

Using the `DefinedType::Event` allows us to restrict the `emit()` call to only classes that inherit from `Event` in the compiler.

Closes #1 