### PR TITLE
Allow pubkeys as seeds

### DIFF
--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -1234,6 +1234,23 @@ impl BuiltinSource for Prelude {
                 )),
                 _ => None,
             },
+            Self::Pubkey => match builtin {
+                Builtin::Prelude(Self::Seed) => Some((
+                    Ty::prelude(self.clone(), vec![]).into(),
+                    Ty::Transformed(
+                        ty.clone().into(),
+                        Transformation::new(|mut expr| {
+                            let obj = expr.obj.without_borrows();
+                            expr.obj = ExpressionObj::Rendered(quote! {
+                                #obj.as_ref()
+                            });
+
+                            Ok(Transformed::Expression(expr))
+                        }),
+                    ),
+                )),
+                _ => None,
+            },
             // TODO copied straight from Signer, should extract to a function or something
             Self::Program => match builtin {
                 Builtin::Prelude(Self::Account | Self::InitAccount) => {


### PR DESCRIPTION
This PR allows setting pubkeys as seeds. It enables code like:

```
class XAccount(Account):
    x: u8

@instruction
def instr(acc: Empty[XAccount], payer: Signer, key: Pubkey):
    acc = acc.init(payer, seeds=[key])
```

Note that I haven't been able to repro the other data types mentioned in the issue (integers, array of u8). See my comment on the issue

Closes #35