### PR TITLE
Fix compile errors in hello.py example

### DIFF
--- a/examples/hello.py
+++ b/examples/hello.py
@@ -1,5 +1,5 @@
 # hello
-# Built with Seahorse v0.1.0
+# Built with Seahorse v0.2.3
 #
 # Greets users to Solana by printing a message and minting them a token!
 
@@ -7,15 +7,20 @@ from seahorse.prelude import *
 
 declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
 
+
 class Hello(Account):
   bump: u8
 
+
 @instruction
 def init(owner: Signer, hello: Empty[Hello], mint: Empty[TokenMint]):
-  init_hello = hello.init(
-    payer = owner,
-    seeds = ['hello']
+  bump = hello.bump()
+
+  hello = hello.init(
+    payer=owner,
+    seeds=['hello']
   )
+
   mint.init(
     payer = owner,
     seeds = ['hello-mint'],
@@ -23,14 +28,16 @@ def init(owner: Signer, hello: Empty[Hello], mint: Empty[TokenMint]):
     authority = hello
   )
 
-  init_hello.bump = hello.bump()
+  hello.bump = bump
+
 
 @instruction
 def say_hello(user_acc: TokenAccount, hello: Hello, mint: TokenMint):
+  bump = hello.bump
   print(f'Hello {user_acc.authority()}, have a token!')
   mint.mint(
     authority = hello,
     to = user_acc,
     amount = u64(1),
-    signer = ['hello', hello.bump]
+    signer = ['hello', bump]
   )


### PR DESCRIPTION
I noticed this example had some errors, related to #39

- `hello` is re-assigned to the initialised account, so that it can be used as `authority`
- `bump` is stored at the start of the instruction, before this re-assign
- Similarly `hello.bump` is stored at the start of `say_hello`, doing `hello.bump` inside `mint.mint` was erroring

With these changes it compiles correctly: https://beta.solpg.io/636d27b177ea7f12846aef21