### PR TITLE
Add @dataclass decorator to generate automatic default class constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `Pubkey.find_program_address()` function, to find a PDA given a list of seeds and the program key
+- Decorator @dataclass for classes to automatically generate a default constructor
+
 
 ### Fixed
 
@@ -21,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Pyth integration
-
 ### Fixed
 
 - System clock is now immutable in instruction contexts (a.k.a. it works now)

--- a/data/const/seahorse_prelude.py
+++ b/data/const/seahorse_prelude.py
@@ -849,6 +849,9 @@ def declare_id(id: str):
 def instruction(function: Callable[..., None]) -> Callable[..., None]:
     """Decorator to turn a function into a program instruction."""
 
+def dataclass(function: Callable[..., None]) -> Callable[..., None]:
+    """Decorator to create an automatic default class constructor."""
+
 def int_bytes(n: Any, be: bool = False) -> List[u8]:
     """
     Convenience method to turn an integer type into a little-endian (by default) list of bytes.

--- a/examples/event.py
+++ b/examples/event.py
@@ -8,6 +8,7 @@ from seahorse.prelude import *
 declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
 
 
+@dataclass
 class HelloEvent(Event):
     data: u8
     title: str
@@ -15,21 +16,6 @@ class HelloEvent(Event):
     # Not yet supported: https://github.com/ameliatastic/seahorse-lang/issues/64
     # items: List[u8]
     # pair: Array[u8, 2]
-
-    def __init__(
-        self,
-        data: u8,
-        title: str,
-        owner: Pubkey,
-        # items: List[u8],
-        # pair: Array[u8, 2],
-
-    ):
-        self.data = data
-        self.title = title
-        self.owner = owner
-        # self.items = items
-        # self.pair = pair
 
 
 @instruction

--- a/src/core/clean/ast.rs
+++ b/src/core/clean/ast.rs
@@ -29,6 +29,7 @@ pub enum TopLevelStatementObj {
         name: String,
         body: Vec<ClassDefStatement>,
         bases: Vec<TyExpression>,
+        decorator_list: Vec<Expression>,
     },
     FunctionDef(FunctionDef),
     Expression(Expression),

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -51,6 +51,7 @@ pub struct Struct {
     pub methods: Vec<(MethodType, Function)>,
     pub constructor: Option<Function>,
     pub is_event: bool,
+    pub is_dataclass: bool,
 }
 
 /// An Anchor account definition.

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -1036,7 +1036,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                         ) => match signature {
                                             Signature::Class(ClassSignature::Struct(
                                                 StructSignature {
-                                                    is_account, is_event, fields: mut fields_map, methods: mut methods_map, ..
+                                                    is_account, is_event, is_dataclass, fields: mut fields_map, methods: mut methods_map, ..
                                                 },
                                             )) => {
                                                 let mut fields = vec![];
@@ -1090,6 +1090,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                                         methods,
                                                         constructor,
                                                         is_event,
+                                                        is_dataclass,
                                                     })
                                                 };
 

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -56,12 +56,15 @@ impl Error {
                 "Help: new accounts must be created through the Solana system program, try using the Empty.init(...) syntax instead."
             ),
             Self::InvalidClassDecorator(dec) => {
-                CoreError::make_raw(format!("\"{:?}\" is not a valid decorator", dec), "")
+                CoreError::make_raw(
+                    format!("\"{:#?}\" is not a valid decorator", dec), 
+                    "Decorators must be a string"
+                )
             }
             Self::UnsupportedClassDecorator(dec) => {
                 CoreError::make_raw(
                     format!("{} is not a supported class decorator", dec),
-                    "Hint: Only dataclass is currently supported for classes",
+                    "Hint: Only dataclass is currently supported for classes. Imported paths like \"seahorse.prelude.dataclass\" are not currently supported.",
                 )
             }
             Self::DuplicateClassField(field) => {
@@ -306,6 +309,9 @@ fn build_signature(
                     }
                     ca::ExpressionObj::Id(d) => {
                         return Err(Error::UnsupportedClassDecorator(d.to_string()).core(&loc))
+                    }
+                    ca::ExpressionObj::Attribute { name, .. } => {
+                        return Err(Error::UnsupportedClassDecorator(name.to_string()).core(&loc))
                     }
                     _ => return Err(Error::InvalidClassDecorator(decorator.clone()).core(&loc)),
                 }

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -1,7 +1,7 @@
 // TODO just throwing everything into mod.rs for now, don't want to deal with keeping things clean
 // yet
 use crate::core::{
-    clean::ast as ca,
+    clean::ast::{self as ca, ParamObj, Params},
     compile::{
         ast::ExpressionObj,
         build::{Transformation, Transformed},
@@ -26,6 +26,9 @@ enum Error {
     InvalidClassField,
     InvalidClassConstructor,
     AccountConstructor,
+    InvalidClassDecorator(ca::ExpressionObj),
+    UnsupportedClassDecorator(String),
+    DuplicateClassField(String),
 }
 
 impl Error {
@@ -51,7 +54,22 @@ impl Error {
             Self::AccountConstructor => CoreError::make_raw(
                 "accounts may not have constructors",
                 "Help: new accounts must be created through the Solana system program, try using the Empty.init(...) syntax instead."
-            )
+            ),
+            Self::InvalidClassDecorator(dec) => {
+                CoreError::make_raw(format!("\"{:?}\" is not a valid decorator", dec), "")
+            }
+            Self::UnsupportedClassDecorator(dec) => {
+                CoreError::make_raw(
+                    format!("{} is not a supported class decorator", dec),
+                    "Hint: Only dataclass is currently supported for classes",
+                )
+            }
+            Self::DuplicateClassField(field) => {
+                CoreError::make_raw(
+                    format!("duplicate class field {}", field),
+                    "Hint: a field can only be declared in a class once"
+                )
+            }
         }
         .located(loc.clone())
     }
@@ -89,6 +107,7 @@ pub enum ClassSignature {
 pub struct StructSignature {
     pub is_account: bool,
     pub is_event: bool,
+    pub is_dataclass: bool,
     pub bases: Vec<Ty>,
     pub fields: HashMap<String, Ty>,
     pub methods: HashMap<String, (MethodType, FunctionSignature)>,
@@ -218,12 +237,14 @@ impl TryFrom<NamespaceOutput> for SignOutput {
                         Signature::Class(ClassSignature::Struct(StructSignature {
                             is_account,
                             is_event,
+                            is_dataclass,
                             bases,
                             fields,
                             methods,
                         })) => Signature::Class(ClassSignature::Struct(StructSignature {
                             is_account,
                             is_event,
+                            is_dataclass,
                             bases,
                             fields: fields
                                 .into_iter()
@@ -266,11 +287,30 @@ fn build_signature(
     let Located(loc, obj) = def;
 
     match obj {
-        ca::TopLevelStatementObj::ClassDef { body, bases, .. } => {
+        ca::TopLevelStatementObj::ClassDef {
+            body,
+            bases,
+            decorator_list,
+            ..
+        } => {
             let mut is_account = false;
             let mut is_enum = false;
             let mut is_event = false;
             let mut bases_ = vec![];
+            let mut is_dataclass = false;
+
+            for Located(loc, decorator) in decorator_list.into_iter() {
+                match decorator {
+                    ca::ExpressionObj::Id(d) if d == "dataclass" => {
+                        is_dataclass = true;
+                    }
+                    ca::ExpressionObj::Id(d) => {
+                        return Err(Error::UnsupportedClassDecorator(d.to_string()).core(&loc))
+                    }
+                    _ => return Err(Error::InvalidClassDecorator(decorator.clone()).core(&loc)),
+                }
+            }
+
             for base in bases.iter() {
                 let base = root.build_ty(base, abs)?;
                 match base {
@@ -327,7 +367,9 @@ fn build_signature(
                 })))
             } else {
                 let mut fields = HashMap::new();
+                let mut fields_ordered = vec![];
                 let mut methods = HashMap::new();
+                let mut has_ctor = false;
 
                 for statement in body.iter() {
                     let Located(loc, obj) = statement;
@@ -338,7 +380,17 @@ fn build_signature(
                                 return Err(Error::InvalidClassField.core(loc));
                             }
 
-                            fields.insert(name.clone(), root.build_ty(&ty.as_ref().unwrap(), abs)?);
+                            let field_ty = root.build_ty(&ty.as_ref().unwrap(), abs)?;
+
+                            let existing_field = fields.insert(name.clone(), field_ty);
+
+                            if existing_field.is_some() {
+                                return Err(Error::DuplicateClassField(name.clone()).core(loc));
+                            }
+
+                            let ty_expr = ty.as_ref().unwrap().clone();
+
+                            fields_ordered.push((name, ty_expr));
                         }
                         ca::ClassDefStatementObj::MethodDef(ca::FunctionDef {
                             name,
@@ -354,6 +406,7 @@ fn build_signature(
                                     if returns.is_some() {
                                         return Err(Error::InvalidClassConstructor.core(loc));
                                     }
+                                    has_ctor = true;
                                 }
 
                                 methods.insert(
@@ -380,10 +433,40 @@ fn build_signature(
                     }
                 }
 
+                if !has_ctor && is_dataclass {
+                    // If there is no constructor for a dataclass, then for typechecking purposes
+                    // we add a __init__ function, which takes all fields as params, and returns None
+
+                    // Convert the fields to param objects
+                    let param_objs = fields_ordered.iter().map(|(name, ty_expr)| ParamObj {
+                        arg: name.to_string(),
+                        annotation: ty_expr.clone(),
+                    });
+
+                    let params: Params = Params {
+                        is_instance_method: true,
+                        params: param_objs
+                            .map(|p| Located(loc.clone(), p.clone()))
+                            .collect::<Vec<Located<ParamObj>>>(),
+                    };
+
+                    methods.insert(
+                        String::from("__init__"),
+                        (
+                            MethodType::Instance,
+                            build_function_signature(&params, &None, abs, root)?,
+                        ),
+                    );
+                }
+
                 Ok(Signature::Class(ClassSignature::Struct(StructSignature {
                     is_account,
                     is_event,
-                    fields,
+                    is_dataclass,
+                    fields: fields
+                        .iter()
+                        .map(|(name, ty)| (name.clone(), ty.clone()))
+                        .collect::<HashMap<String, Ty>>(),
                     bases: bases_,
                     methods,
                 })))

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -147,6 +147,7 @@ impl ToTokens for Struct {
             methods,
             constructor,
             is_event,
+            is_dataclass,
         } = self;
         let name = ident(name);
 
@@ -178,6 +179,25 @@ impl ToTokens for Struct {
                     let obj = Mutable::new(#name::default());
                     obj.__init__(#(#ext_param_names),*);
                     return obj;
+                }
+            });
+        } else if *is_dataclass {
+            let ctor_params = fields.iter().map(|(name, ty_expr, _)| {
+                let name = ident(name);
+
+                quote! { #name: #ty_expr }
+            });
+
+            let ctor_param_names = fields.iter().map(|(name, _, _)| {
+                let name = ident(name);
+
+                quote! { #name }
+            });
+
+            static_methods.push(quote! {
+                pub fn __new__(#(#ctor_params), *) -> Mutable<Self> {
+                    let obj = #name { #(#ctor_param_names),* };
+                    return Mutable::new(obj);
                 }
             });
         }

--- a/tests/compiled-examples/event.rs
+++ b/tests/compiled-examples/event.rs
@@ -21,14 +21,6 @@ pub struct HelloEvent {
 }
 
 impl Mutable<HelloEvent> {
-    pub fn __init__(&self, mut data: u8, mut title: String, mut owner: Pubkey) -> () {
-        assign!(self.borrow_mut().data, data);
-
-        assign!(self.borrow_mut().title, title);
-
-        assign!(self.borrow_mut().owner, owner);
-    }
-
     fn __emit__(&self) {
         let e = self.borrow();
 
@@ -42,11 +34,9 @@ impl Mutable<HelloEvent> {
 
 impl HelloEvent {
     pub fn __new__(data: u8, title: String, owner: Pubkey) -> Mutable<Self> {
-        let obj = Mutable::new(HelloEvent::default());
+        let obj = HelloEvent { data, title, owner };
 
-        obj.__init__(data, title, owner);
-
-        return obj;
+        return Mutable::new(obj);
     }
 }
 


### PR DESCRIPTION
This PR adds a new decorator `@dataclass` for classes. When it is used a default constructor is generated, which takes all fields as parameters and creates a new mutable instance. For example you can now write a class like this:

```py
@dataclass
class PixelChanged(Event):
    pos_x: u8
    pos_y: u8
    col_r: u8
    col_g: u8
    col_b: u8
```

And then in an instruction:

```py
    change_event = PixelChanged(
        pos_x,
        pos_y,
        init_col_r,
        init_col_g,
        init_col_b
    )
    change_event.emit()
```

Previously you needed to write the `def __init__` yourself, now it's generated for you if you use this decorator and don't write one. Note that the decorator is `@dataclass` to match a Python one that does something similar: https://docs.python.org/3/library/dataclasses.html

Most of the magic is in the compile:sign stage. If there is a `dataclass` decorator, and no `__init__` instance method, then we generate the signature of one. This is done by converting the fields of the class to params, and building a function signature from them. This means that code like `PixelChanged(x,y,r,g,b)` will type check correctly, because internally the compiler is aware of such a function call.

The rest is in the generate stage. If there is not a user-defined constructor and it is a dataclass, then we generate a `__new__` function that looks like:

```rs
impl PixelChanged {
    pub fn __new__(pos_x: u8, pos_y: u8, col_r: u8, col_g: u8, col_b: u8) -> Mutable<Self> {
        let obj = PixelChanged {
            pos_x,
            pos_y,
            col_r,
            col_g,
            col_b,
        };

        return Mutable::new(obj);
    }
}
```

Closes #43 