### PR TITLE
Fix: Make Signer mutable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - System clock is now immutable in instruction contexts (a.k.a. it works now)
+- Fix accessing index 0 of arrays
 
 ## [0.2.3]
 

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -194,7 +194,6 @@ impl Ty {
                 Prelude::RustFloat
                 | Prelude::RustInt(..)
                 | Prelude::Pubkey
-                | Prelude::Signer
                 | Prelude::Empty
                 | Prelude::TokenMint
                 | Prelude::TokenAccount


### PR DESCRIPTION
This was broken by my change to set account mutability based on `is_mut` in #45 

Because `Prelude::Signer` was immutable, the account generated was. This caused an error when initialising an account with a signer as payer, because the payer must be mutable. 