### PR TITLE
Fix wrapped_index for index=0

### DIFF
--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -1273,7 +1273,7 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
             // Pythonic indexing for vec/array types (Seahorse List, Array types)
             impl<T: Clone> Mutable<Vec<T>> {
                 pub fn wrapped_index(&self, mut index: i128) -> usize {
-                    if index > 0 {
+                    if index >= 0 {
                         return index.try_into().unwrap();
                     }
 
@@ -1284,7 +1284,7 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
 
             impl<T: Clone, const N: usize> Mutable<[T; N]> {
                 pub fn wrapped_index(&self, mut index: i128) -> usize {
-                    if index > 0 {
+                    if index >= 0 {
                         return index.try_into().unwrap();
                     }
 


### PR DESCRIPTION
There was a bug when accessing an array at index 0, caused by `wrapped_index`. The problem was that it skipped the `index > 0` branch, and then added the array length to generate the index. This feature supports negative indices, but isn't the right code path for index=0.

Eg. if the list is 5 elements, this code would generate an index of 5 when you try to index 0, which is an error. The fix is to include 0 in the first branch, meaning we just index at 0.

Closes #51 