### PR TITLE
Refactor intermediate datatypes to make the compiler output stable

### DIFF
--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -2,14 +2,14 @@ use proc_macro2::TokenStream;
 
 use super::{super::generate::Feature, builtin::prelude::MethodType, check::Ty};
 use crate::core::Tree;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 /// A compilation artifact. Does not handle lib.rs, which will be generated separately.
 ///
 /// Collects and propagates features to make generation a bit easier.
 #[derive(Clone, Debug)]
 pub struct Artifact {
-    pub features: HashSet<Feature>,
+    pub features: BTreeSet<Feature>,
     pub uses: Vec<Use>,
     pub directives: Vec<Directive>,
     pub constants: Vec<Constant>,
@@ -135,7 +135,7 @@ pub struct InstructionContext {
     pub name: String,
     pub params: Vec<(String, TyExpr)>,
     pub accounts: Vec<(String, ContextAccount)>,
-    pub inferred_accounts: HashMap<String, ContextAccount>,
+    pub inferred_accounts: BTreeMap<String, ContextAccount>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -2,7 +2,7 @@
 // yet
 use crate::{
     core::{
-        clean::ast::{self, ComprehensionPart, Expression, ParamObj},
+        clean::ast::{self, ComprehensionPart, ParamObj},
         compile::{ast::*, builtin::*, check::*},
         generate::Feature,
         util::*,
@@ -12,11 +12,11 @@ use crate::{
 use heck::ToPascalCase;
 use quote::quote;
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     rc::Rc,
 };
 
-use super::{check::*, namespace::*, sign::*};
+use super::{namespace::*, sign::*};
 
 enum Error {
     InvalidDecorator(Ty),
@@ -341,7 +341,7 @@ impl<'a> Context<'a> {
                         name,
                         params,
                         accounts,
-                        inferred_accounts: HashMap::new(),
+                        inferred_accounts: BTreeMap::new(),
                     });
                 }
                 dec => {
@@ -987,7 +987,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
         let mut tree = tree
             .map_with_path(|(mut contexts, (mut signatures, namespace)), path| {
                 let mut artifact = Artifact {
-                    features: HashSet::new(),
+                    features: BTreeSet::new(),
                     uses: vec![Use { rooted: true, tree: Tree::Node(HashMap::new()) }],
                     directives: vec![],
                     constants: vec![],

--- a/src/core/compile/builtin/mod.rs
+++ b/src/core/compile/builtin/mod.rs
@@ -1,5 +1,4 @@
 use crate::core::{compile::check::*, util::*};
-pub use std::collections::HashMap;
 
 pub mod prelude;
 pub mod pyth;

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -7,6 +7,7 @@ pub use crate::core::{
 };
 use crate::match1;
 use quote::quote;
+use std::collections::BTreeMap;
 pub use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -78,7 +79,7 @@ pub fn namespace() -> Namespace {
         ("instruction", Prelude::Instruction),
     ];
 
-    let mut namespace = HashMap::new();
+    let mut namespace = BTreeMap::new();
     for (name, obj) in data.into_iter() {
         namespace.insert(
             name.to_string(),

--- a/src/core/compile/builtin/pyth.rs
+++ b/src/core/compile/builtin/pyth.rs
@@ -2,6 +2,8 @@
 
 // why does every builtin have to start with a P
 
+use std::collections::BTreeMap;
+
 use crate::core::compile::builtin::*;
 pub use crate::core::{
     compile::{ast::*, build::*, check::*, namespace::*, sign::*},
@@ -29,7 +31,7 @@ pub fn namespace() -> Namespace {
         ("Price", Pyth::Price),
     ];
 
-    let mut namespace = HashMap::new();
+    let mut namespace = BTreeMap::new();
     for (name, obj) in data.into_iter() {
         namespace.insert(
             name.to_string(),

--- a/src/core/compile/namespace/mod.rs
+++ b/src/core/compile/namespace/mod.rs
@@ -7,7 +7,7 @@ use crate::core::{
     preprocess::{self as pre, Module},
     util::*,
 };
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, VecDeque};
 
 enum Error {
     ImportNotFound(Vec<String>),
@@ -68,7 +68,7 @@ pub struct NamespaceOutput {
 }
 
 /// The (global) namespace for a module.
-pub type Namespace = HashMap<String, Export>;
+pub type Namespace = BTreeMap<String, Export>;
 
 impl Tree<Namespace> {
     /// Get an item given an absolute path.
@@ -328,7 +328,7 @@ fn build_python_namespace(
     path: &Vec<String>,
     module: &ca::Module,
 ) -> CResult<Namespace> {
-    let mut namespace = HashMap::new();
+    let mut namespace = BTreeMap::new();
 
     for statement in module.statements.iter() {
         let Located(loc, obj) = statement;

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -7,17 +7,17 @@ use quote::{format_ident, quote, ToTokens};
 use regex::Regex;
 #[cfg(not(target_arch = "wasm32"))]
 use rustfmt_wrapper::{config::*, rustfmt_config, Error as RustfmtError};
-use std::{cell::RefCell, collections::HashSet, rc::Rc};
+use std::{cell::RefCell, collections::BTreeSet, rc::Rc};
 
 use super::compile::builtin::prelude::MethodType;
 
 pub struct GenerateOutput {
     pub tree: Tree<String>,
-    pub features: HashSet<Feature>,
+    pub features: BTreeSet<Feature>,
 }
 
 /// A set of features that need to be turned on in order to compile an artifact.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum Feature {
     Pyth,
 }
@@ -1518,7 +1518,7 @@ impl TryFrom<(BuildOutput, String)> for GenerateOutput {
         let origin = build_output.tree.get_leaf(&build_output.origin).unwrap();
         let lib = make_lib(origin, &build_output.origin, &program_name)?;
 
-        let features = Rc::new(RefCell::new(HashSet::new()));
+        let features = Rc::new(RefCell::new(BTreeSet::new()));
 
         let mut tree = build_output
             .tree


### PR DESCRIPTION
This means that if we compile the same code repeatedly the output is identical. The motivation for this is to allow adding lightweight infrastructure to detect whether/how a PR changes the compile output for the example Python files. Having a stable output is a prerequisite for this to avoid false positives where eg. functions are just rearranged.

Where we've used `HashMap` and `HashSet` data structures the sort order is undefined, and in practice if you compile multiple times you'll get different outputs. 

See suggestion in Discord: https://discordapp.com/channels/1005658120548270224/1006027721127776388/1042345155522474034

To test this I compiled the examples 20 times each:

```sh
# examples/
for f in ./*.py
do
    for i in {1..20}
    do
        ../target/debug/seahorse compile $f > compiled/$f$i.rs
    done
done
```

And then verified with `md5 compiled/*` that all instances of the same file are identical

Intentionally didn't update changelog BTW! :D 