### PR TITLE
Remove path from fields in Accounts struct

### DIFF
--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -634,9 +634,8 @@ impl ToTokens for AccountTyExpr {
                 quote! { #ty_expr }
             }
             Self::Defined(ty_expr) => {
-                // let ty_expr = ContextBaseTyExpr(ty_expr);
-                let ty_expr = StaticPath(ty_expr);
-
+                // Get the last part of the path
+                let ty_expr = ident(ty_expr.last().unwrap());
                 quote! { Box<Account<'info, #ty_expr>> }
             }
             Self::Signer => quote! { Signer<'info> },


### PR DESCRIPTION
This PR updates the fields of an account struct from eg:

` pub post: Box<Account<'info, dot::program::Post>>,`

To eg:

` pub post: Box<Account<'info, Post>>,`

This works correctly because lib.rs includes `use dot::program::*;`, so either form is equivalent.

This is a workaround for an issue parsing seeds in Anchor: https://github.com/coral-xyz/anchor/pull/2268

In short, Anchor reads the imported `Post` struct as just being called `Post`, but reads the account as `dot::program::Post`, which doesn't match and errors. By just generating it as `Post` in Seahorse we avoid this issue.

 Full details in the Anchor PR description + Seahorse Discord: https://discord.com/channels/1005658120548270224/1005658120988655647/1043989626114814012