### PR TITLE
Add CI workflow: compile example files + check for any changes

### DIFF
--- a/.github/workflows/check-examples.yml
+++ b/.github/workflows/check-examples.yml
@@ -1,0 +1,28 @@
+name: check-examples
+
+# Run on pushes to main, all pull requests
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+
+jobs:
+  check-examples:
+    name: Check Examples
+    runs-on: ubuntu-latest
+    steps:
+      # checkout + build
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup toolchain install stable --profile minimal
+      # See https://github.com/Swatinem/rust-cache
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build
+      # compile the examples + check for changes
+      - name: Compile all examples
+        run: ./tests/compile-examples.sh
+      - name: Check for any changes
+        run: ./tests/check-for-changes.sh

--- a/tests/check-for-changes.sh
+++ b/tests/check-for-changes.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# This script checks git status, and exits with an error if there are any changes
+# It's intended to ensure that all changes to compiled-examples/ are checked in
+
+status=$(git status --porcelain)
+
+if [ -n "$status" ]
+then
+    echo "Found unexpected changes. You probably need to run ./tests/compile-examples.sh and check in any resulting changes"
+    # log the git status and diff
+    git status
+    git diff
+    exit 1
+fi

--- a/tests/compile-examples.sh
+++ b/tests/compile-examples.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# get script directory, and root directory (which is one level higher)
+# this allows the script to be run from any directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+for f in ${ROOT_DIR}/examples/*.py
+do
+    # get just the filename without directories or file extension (eg calculator)
+    name="$(basename -- $f .py)"
+    ${ROOT_DIR}/target/debug/seahorse compile $f > ${SCRIPT_DIR}/compiled-examples/$name.rs
+done

--- a/tests/compiled-examples/calculator.rs
+++ b/tests/compiled-examples/calculator.rs
@@ -1,0 +1,380 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{assign, id, index_assign, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+#[account]
+#[derive(Debug)]
+pub struct Calculator {
+    pub owner: Pubkey,
+    pub display: i64,
+}
+
+impl<'info, 'entrypoint> Calculator {
+    pub fn load(
+        account: &'entrypoint mut Box<Account<'info, Self>>,
+        programs_map: &'entrypoint ProgramsMap<'info>,
+    ) -> Mutable<LoadedCalculator<'info, 'entrypoint>> {
+        let owner = account.owner.clone();
+        let display = account.display;
+
+        Mutable::new(LoadedCalculator {
+            __account__: account,
+            __programs__: programs_map,
+            owner,
+            display,
+        })
+    }
+
+    pub fn store(loaded: Mutable<LoadedCalculator>) {
+        let mut loaded = loaded.borrow_mut();
+        let owner = loaded.owner.clone();
+
+        loaded.__account__.owner = owner;
+
+        let display = loaded.display;
+
+        loaded.__account__.display = display;
+    }
+}
+
+#[derive(Debug)]
+pub struct LoadedCalculator<'info, 'entrypoint> {
+    pub __account__: &'entrypoint mut Box<Account<'info, Calculator>>,
+    pub __programs__: &'entrypoint ProgramsMap<'info>,
+    pub owner: Pubkey,
+    pub display: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, AnchorSerialize, AnchorDeserialize, Copy)]
+pub enum Operation {
+    ADD,
+    SUB,
+    MUL,
+    DIV,
+}
+
+impl Default for Operation {
+    fn default() -> Self {
+        Operation::ADD
+    }
+}
+
+pub fn do_operation_handler<'info>(
+    mut owner: SeahorseSigner<'info, '_>,
+    mut calculator: Mutable<LoadedCalculator<'info, '_>>,
+    mut op: Operation,
+    mut num: i64,
+) -> () {
+    if !(owner.key() == calculator.borrow().owner) {
+        panic!("This is not your calculator!");
+    }
+
+    if op == Operation::ADD {
+        assign!(
+            calculator.borrow_mut().display,
+            calculator.borrow().display + num
+        );
+    } else {
+        if op == Operation::SUB {
+            assign!(
+                calculator.borrow_mut().display,
+                calculator.borrow().display - num
+            );
+        } else {
+            if op == Operation::MUL {
+                assign!(
+                    calculator.borrow_mut().display,
+                    calculator.borrow().display * num
+                );
+            } else {
+                if op == Operation::DIV {
+                    assign!(
+                        calculator.borrow_mut().display,
+                        calculator.borrow().display / num
+                    );
+                }
+            }
+        }
+    }
+}
+
+pub fn init_calculator_handler<'info>(
+    mut owner: SeahorseSigner<'info, '_>,
+    mut calculator: Empty<Mutable<LoadedCalculator<'info, '_>>>,
+) -> () {
+    let mut calculator = calculator.account.clone();
+
+    assign!(calculator.borrow_mut().owner, owner.key());
+}
+
+pub fn reset_calculator_handler<'info>(
+    mut owner: SeahorseSigner<'info, '_>,
+    mut calculator: Mutable<LoadedCalculator<'info, '_>>,
+) -> () {
+    solana_program::msg!(
+        "{:?} {} {:?}",
+        owner.key(),
+        "is resetting a calculator",
+        calculator.borrow().__account__.key()
+    );
+
+    if !(owner.key() == calculator.borrow().owner) {
+        panic!("This is not your calculator!");
+    }
+
+    assign!(calculator.borrow_mut().display, 0);
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+pub mod seahorse_util {
+    use super::*;
+
+    #[cfg(feature = "pyth-sdk-solana")]
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: Clone> Mutable<Vec<T>> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    impl<T: Clone, const N: usize> Mutable<[T; N]> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+}
+
+#[program]
+mod calculator {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    # [instruction (op : Operation , num : i64)]
+    pub struct DoOperation<'info> {
+        #[account(mut)]
+        pub owner: Signer<'info>,
+        #[account(mut)]
+        pub calculator: Box<Account<'info, dot::program::Calculator>>,
+    }
+
+    pub fn do_operation(ctx: Context<DoOperation>, op: Operation, num: i64) -> Result<()> {
+        let mut programs = HashMap::new();
+        let programs_map = ProgramsMap(programs);
+        let owner = SeahorseSigner {
+            account: &ctx.accounts.owner,
+            programs: &programs_map,
+        };
+
+        let calculator =
+            dot::program::Calculator::load(&mut ctx.accounts.calculator, &programs_map);
+
+        do_operation_handler(owner.clone(), calculator.clone(), op, num);
+
+        dot::program::Calculator::store(calculator);
+
+        return Ok(());
+    }
+
+    #[derive(Accounts)]
+    pub struct InitCalculator<'info> {
+        #[account(mut)]
+        pub owner: Signer<'info>,
+        # [account (init , space = std :: mem :: size_of :: < dot :: program :: Calculator > () + 8 , payer = owner , seeds = ["Calculator" . as_bytes () . as_ref () , owner . key () . as_ref ()] , bump)]
+        pub calculator: Box<Account<'info, dot::program::Calculator>>,
+        pub rent: Sysvar<'info, Rent>,
+        pub system_program: Program<'info, System>,
+    }
+
+    pub fn init_calculator(ctx: Context<InitCalculator>) -> Result<()> {
+        let mut programs = HashMap::new();
+
+        programs.insert(
+            "system_program",
+            ctx.accounts.system_program.to_account_info(),
+        );
+
+        let programs_map = ProgramsMap(programs);
+        let owner = SeahorseSigner {
+            account: &ctx.accounts.owner,
+            programs: &programs_map,
+        };
+
+        let calculator = Empty {
+            account: dot::program::Calculator::load(&mut ctx.accounts.calculator, &programs_map),
+            bump: ctx.bumps.get("calculator").map(|bump| *bump),
+        };
+
+        init_calculator_handler(owner.clone(), calculator.clone());
+
+        dot::program::Calculator::store(calculator.account);
+
+        return Ok(());
+    }
+
+    #[derive(Accounts)]
+    pub struct ResetCalculator<'info> {
+        #[account(mut)]
+        pub owner: Signer<'info>,
+        #[account(mut)]
+        pub calculator: Box<Account<'info, dot::program::Calculator>>,
+    }
+
+    pub fn reset_calculator(ctx: Context<ResetCalculator>) -> Result<()> {
+        let mut programs = HashMap::new();
+        let programs_map = ProgramsMap(programs);
+        let owner = SeahorseSigner {
+            account: &ctx.accounts.owner,
+            programs: &programs_map,
+        };
+
+        let calculator =
+            dot::program::Calculator::load(&mut ctx.accounts.calculator, &programs_map);
+
+        reset_calculator_handler(owner.clone(), calculator.clone());
+
+        dot::program::Calculator::store(calculator);
+
+        return Ok(());
+    }
+}
+

--- a/tests/compiled-examples/fizzbuzz.rs
+++ b/tests/compiled-examples/fizzbuzz.rs
@@ -1,0 +1,296 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{assign, id, index_assign, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+#[account]
+#[derive(Debug)]
+pub struct FizzBuzz {
+    pub fizz: bool,
+    pub buzz: bool,
+    pub n: u64,
+}
+
+impl<'info, 'entrypoint> FizzBuzz {
+    pub fn load(
+        account: &'entrypoint mut Box<Account<'info, Self>>,
+        programs_map: &'entrypoint ProgramsMap<'info>,
+    ) -> Mutable<LoadedFizzBuzz<'info, 'entrypoint>> {
+        let fizz = account.fizz.clone();
+        let buzz = account.buzz.clone();
+        let n = account.n;
+
+        Mutable::new(LoadedFizzBuzz {
+            __account__: account,
+            __programs__: programs_map,
+            fizz,
+            buzz,
+            n,
+        })
+    }
+
+    pub fn store(loaded: Mutable<LoadedFizzBuzz>) {
+        let mut loaded = loaded.borrow_mut();
+        let fizz = loaded.fizz.clone();
+
+        loaded.__account__.fizz = fizz;
+
+        let buzz = loaded.buzz.clone();
+
+        loaded.__account__.buzz = buzz;
+
+        let n = loaded.n;
+
+        loaded.__account__.n = n;
+    }
+}
+
+#[derive(Debug)]
+pub struct LoadedFizzBuzz<'info, 'entrypoint> {
+    pub __account__: &'entrypoint mut Box<Account<'info, FizzBuzz>>,
+    pub __programs__: &'entrypoint ProgramsMap<'info>,
+    pub fizz: bool,
+    pub buzz: bool,
+    pub n: u64,
+}
+
+pub fn do_fizzbuzz_handler<'info>(
+    mut fizzbuzz: Mutable<LoadedFizzBuzz<'info, '_>>,
+    mut n: u64,
+) -> () {
+    assign!(fizzbuzz.borrow_mut().fizz, (n % 3) == 0);
+
+    assign!(fizzbuzz.borrow_mut().buzz, (n % 5) == 0);
+
+    if (!fizzbuzz.borrow().fizz) && (!fizzbuzz.borrow().buzz) {
+        assign!(fizzbuzz.borrow_mut().n, n);
+    } else {
+        assign!(fizzbuzz.borrow_mut().n, 0);
+    }
+}
+
+pub fn init_handler<'info>(
+    mut owner: SeahorseSigner<'info, '_>,
+    mut fizzbuzz: Empty<Mutable<LoadedFizzBuzz<'info, '_>>>,
+) -> () {
+    fizzbuzz.account.clone();
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+pub mod seahorse_util {
+    use super::*;
+
+    #[cfg(feature = "pyth-sdk-solana")]
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: Clone> Mutable<Vec<T>> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    impl<T: Clone, const N: usize> Mutable<[T; N]> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+}
+
+#[program]
+mod fizzbuzz {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    # [instruction (n : u64)]
+    pub struct DoFizzbuzz<'info> {
+        #[account(mut)]
+        pub fizzbuzz: Box<Account<'info, dot::program::FizzBuzz>>,
+    }
+
+    pub fn do_fizzbuzz(ctx: Context<DoFizzbuzz>, n: u64) -> Result<()> {
+        let mut programs = HashMap::new();
+        let programs_map = ProgramsMap(programs);
+        let fizzbuzz = dot::program::FizzBuzz::load(&mut ctx.accounts.fizzbuzz, &programs_map);
+
+        do_fizzbuzz_handler(fizzbuzz.clone(), n);
+
+        dot::program::FizzBuzz::store(fizzbuzz);
+
+        return Ok(());
+    }
+
+    #[derive(Accounts)]
+    pub struct Init<'info> {
+        #[account(mut)]
+        pub owner: Signer<'info>,
+        # [account (init , space = std :: mem :: size_of :: < dot :: program :: FizzBuzz > () + 8 , payer = owner , seeds = ["fizzbuzz" . as_bytes () . as_ref () , owner . key () . as_ref ()] , bump)]
+        pub fizzbuzz: Box<Account<'info, dot::program::FizzBuzz>>,
+        pub rent: Sysvar<'info, Rent>,
+        pub system_program: Program<'info, System>,
+    }
+
+    pub fn init(ctx: Context<Init>) -> Result<()> {
+        let mut programs = HashMap::new();
+
+        programs.insert(
+            "system_program",
+            ctx.accounts.system_program.to_account_info(),
+        );
+
+        let programs_map = ProgramsMap(programs);
+        let owner = SeahorseSigner {
+            account: &ctx.accounts.owner,
+            programs: &programs_map,
+        };
+
+        let fizzbuzz = Empty {
+            account: dot::program::FizzBuzz::load(&mut ctx.accounts.fizzbuzz, &programs_map),
+            bump: ctx.bumps.get("fizzbuzz").map(|bump| *bump),
+        };
+
+        init_handler(owner.clone(), fizzbuzz.clone());
+
+        dot::program::FizzBuzz::store(fizzbuzz.account);
+
+        return Ok(());
+    }
+}
+

--- a/tests/compiled-examples/hello.rs
+++ b/tests/compiled-examples/hello.rs
@@ -1,0 +1,335 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{assign, id, index_assign, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+#[account]
+#[derive(Debug)]
+pub struct Hello {
+    pub bump: u8,
+}
+
+impl<'info, 'entrypoint> Hello {
+    pub fn load(
+        account: &'entrypoint mut Box<Account<'info, Self>>,
+        programs_map: &'entrypoint ProgramsMap<'info>,
+    ) -> Mutable<LoadedHello<'info, 'entrypoint>> {
+        let bump = account.bump;
+
+        Mutable::new(LoadedHello {
+            __account__: account,
+            __programs__: programs_map,
+            bump,
+        })
+    }
+
+    pub fn store(loaded: Mutable<LoadedHello>) {
+        let mut loaded = loaded.borrow_mut();
+        let bump = loaded.bump;
+
+        loaded.__account__.bump = bump;
+    }
+}
+
+#[derive(Debug)]
+pub struct LoadedHello<'info, 'entrypoint> {
+    pub __account__: &'entrypoint mut Box<Account<'info, Hello>>,
+    pub __programs__: &'entrypoint ProgramsMap<'info>,
+    pub bump: u8,
+}
+
+pub fn init_handler<'info>(
+    mut owner: SeahorseSigner<'info, '_>,
+    mut hello: Empty<Mutable<LoadedHello<'info, '_>>>,
+    mut mint: Empty<SeahorseAccount<'info, '_, Mint>>,
+) -> () {
+    let mut bump = hello.bump.unwrap();
+    let mut hello = hello.account.clone();
+
+    mint.account.clone();
+
+    assign!(hello.borrow_mut().bump, bump);
+}
+
+pub fn say_hello_handler<'info>(
+    mut user_acc: SeahorseAccount<'info, '_, TokenAccount>,
+    mut hello: Mutable<LoadedHello<'info, '_>>,
+    mut mint: SeahorseAccount<'info, '_, Mint>,
+) -> () {
+    let mut bump = hello.borrow().bump;
+
+    solana_program::msg!("{}", format!("Hello {:?}, have a token!", user_acc.owner));
+
+    token::mint_to(
+        CpiContext::new_with_signer(
+            mint.programs.get("token_program"),
+            token::MintTo {
+                mint: mint.to_account_info(),
+                authority: hello.borrow().__account__.to_account_info(),
+                to: user_acc.to_account_info(),
+            },
+            &[Mutable::new(vec![
+                "hello".as_bytes().as_ref(),
+                bump.to_le_bytes().as_ref(),
+            ])
+            .borrow()
+            .as_slice()],
+        ),
+        <u64 as TryFrom<_>>::try_from(1).unwrap(),
+    )
+    .unwrap();
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+pub mod seahorse_util {
+    use super::*;
+
+    #[cfg(feature = "pyth-sdk-solana")]
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: Clone> Mutable<Vec<T>> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    impl<T: Clone, const N: usize> Mutable<[T; N]> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+}
+
+#[program]
+mod hello {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    pub struct Init<'info> {
+        #[account(mut)]
+        pub owner: Signer<'info>,
+        # [account (init , space = std :: mem :: size_of :: < dot :: program :: Hello > () + 8 , payer = owner , seeds = ["hello" . as_bytes () . as_ref ()] , bump)]
+        pub hello: Box<Account<'info, dot::program::Hello>>,
+        # [account (init , payer = owner , seeds = ["hello-mint" . as_bytes () . as_ref ()] , bump , mint :: decimals = 0 , mint :: authority = hello)]
+        pub mint: Box<Account<'info, Mint>>,
+        pub rent: Sysvar<'info, Rent>,
+        pub system_program: Program<'info, System>,
+        pub token_program: Program<'info, Token>,
+    }
+
+    pub fn init(ctx: Context<Init>) -> Result<()> {
+        let mut programs = HashMap::new();
+
+        programs.insert(
+            "system_program",
+            ctx.accounts.system_program.to_account_info(),
+        );
+
+        programs.insert(
+            "token_program",
+            ctx.accounts.token_program.to_account_info(),
+        );
+
+        let programs_map = ProgramsMap(programs);
+        let owner = SeahorseSigner {
+            account: &ctx.accounts.owner,
+            programs: &programs_map,
+        };
+
+        let hello = Empty {
+            account: dot::program::Hello::load(&mut ctx.accounts.hello, &programs_map),
+            bump: ctx.bumps.get("hello").map(|bump| *bump),
+        };
+
+        let mint = Empty {
+            account: SeahorseAccount {
+                account: &ctx.accounts.mint,
+                programs: &programs_map,
+            },
+            bump: ctx.bumps.get("mint").map(|bump| *bump),
+        };
+
+        init_handler(owner.clone(), hello.clone(), mint.clone());
+
+        dot::program::Hello::store(hello.account);
+
+        return Ok(());
+    }
+
+    #[derive(Accounts)]
+    pub struct SayHello<'info> {
+        #[account()]
+        pub user_acc: Box<Account<'info, TokenAccount>>,
+        #[account(mut)]
+        pub hello: Box<Account<'info, dot::program::Hello>>,
+        #[account()]
+        pub mint: Box<Account<'info, Mint>>,
+        pub token_program: Program<'info, Token>,
+    }
+
+    pub fn say_hello(ctx: Context<SayHello>) -> Result<()> {
+        let mut programs = HashMap::new();
+
+        programs.insert(
+            "token_program",
+            ctx.accounts.token_program.to_account_info(),
+        );
+
+        let programs_map = ProgramsMap(programs);
+        let user_acc = SeahorseAccount {
+            account: &ctx.accounts.user_acc,
+            programs: &programs_map,
+        };
+
+        let hello = dot::program::Hello::load(&mut ctx.accounts.hello, &programs_map);
+        let mint = SeahorseAccount {
+            account: &ctx.accounts.mint,
+            programs: &programs_map,
+        };
+
+        say_hello_handler(user_acc.clone(), hello.clone(), mint.clone());
+
+        dot::program::Hello::store(hello);
+
+        return Ok(());
+    }
+}
+


### PR DESCRIPTION
This PR is intended to improve our robustness, by requiring that any changes to the compiled output of the example Seahorse files is know about and reviewed. This should mostly avoid me introducing more bugs :p 

I've tested it on my own fork:
- Success: https://github.com/mcintyre94/seahorse-lang/actions/runs/3550019740
- Error (caused by a change in the compiler): https://github.com/mcintyre94/seahorse-lang/actions/runs/3550014723

It hasn't run on this PR, I assume that's a github security limitation for new workflows.

Note that currently the examples are quite limited, there are many areas they don't cover. Improving this in future PRs would be a valuable contribution, and double as extra documentation! But in particular because they're all single files being compiled with `seahorse compile`, the Python imports feature can't currently be tested with it. We might want to add some examples using `seahorse build` in a full-fledged seahorse project going forward. But I think this is a good start and that most things will be better served by simple single file tests.