### PR TITLE
Support strings in events by calling .clone()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Pubkey.find_program_address()` function, to find a PDA given a list of seeds and the program key
 
+### Fixed
+
+- Support strings in events
+
 ## [0.2.4]
 
 ### Added

--- a/examples/event.py
+++ b/examples/event.py
@@ -1,0 +1,42 @@
+# event
+# Built with Seahorse v0.1.0
+#
+# Emit on-chain events
+
+from seahorse.prelude import *
+
+declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
+
+
+class HelloEvent(Event):
+    data: u8
+    title: str
+    owner: Pubkey
+    # Not yet supported: https://github.com/ameliatastic/seahorse-lang/issues/64
+    # items: List[u8]
+    # pair: Array[u8, 2]
+
+    def __init__(
+        self,
+        data: u8,
+        title: str,
+        owner: Pubkey,
+        # items: List[u8],
+        # pair: Array[u8, 2],
+
+    ):
+        self.data = data
+        self.title = title
+        self.owner = owner
+        # self.items = items
+        # self.pair = pair
+
+
+@instruction
+def send_event(
+    sender: Signer,
+    data: u8,
+    title: str
+):
+    event = HelloEvent(data, title, sender.key())
+    event.emit()

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -47,7 +47,7 @@ pub enum TypeDef {
 #[derive(Clone, Debug)]
 pub struct Struct {
     pub name: String,
-    pub fields: Vec<(String, TyExpr)>,
+    pub fields: Vec<(String, TyExpr, Ty)>,
     pub methods: Vec<(MethodType, Function)>,
     pub constructor: Option<Function>,
     pub is_event: bool,

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -1086,7 +1086,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                                 } else {
                                                     TypeDef::Struct(Struct {
                                                         name,
-                                                        fields: fields.into_iter().map(|(name, ty_expr, ty)| (name, ty_expr, ty)).collect(),
+                                                        fields,
                                                         methods,
                                                         constructor,
                                                         is_event,

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -1086,7 +1086,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
                                                 } else {
                                                     TypeDef::Struct(Struct {
                                                         name,
-                                                        fields: fields.into_iter().map(|(name, ty, _)| (name, ty)).collect(),
+                                                        fields: fields.into_iter().map(|(name, ty_expr, ty)| (name, ty_expr, ty)).collect(),
                                                         methods,
                                                         constructor,
                                                         is_event,

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -200,12 +200,9 @@ impl ToTokens for Struct {
         // `impl Class` block.
 
         let event_emit_fn = if *is_event {
-            let fs = fields.iter().map(|(name, ty)| {
+            let fs = fields.iter().map(|(name, ty, original_ty)| {
                 let name = ident(name);
-                let needs_clone = match ty {
-                    TyExpr::Generic { name, .. } if name[0] == "String" => true,
-                    _ => false,
-                };
+                let needs_clone = !original_ty.is_copy();
 
                 if needs_clone {
                     quote! { #name: e.#name.clone() }
@@ -251,7 +248,7 @@ impl ToTokens for Struct {
             }
         };
 
-        let fields = fields.iter().map(|(name, ty)| {
+        let fields = fields.iter().map(|(name, ty, _)| {
             let name = ident(name);
 
             quote! { pub #name: #ty }


### PR DESCRIPTION
Since strings in Rust don't implement `Copy`, we need to call `.clone()` when we read these fields of an event. This PR adds logic to add `.clone()` for only strings.

I've also added an event example which shows various different field types in events. I found that lists and arrays also don't work, but will also need further work, so I've opened a separate issue for them: #64 

Closes #61 
