### PR TITLE
Fix use of account key() as seed

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -8,7 +8,6 @@ on:
       - main
   pull_request:
 
-
 jobs:
   check-examples:
     name: Check Examples
@@ -22,7 +21,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo build
       # compile the examples + check for changes
-      - name: Compile all examples
-        run: ./tests/compile-examples.sh
+      - name: Compile all tests
+        run: ./tests/compile-tests.sh
       - name: Check for any changes
         run: ./tests/check-for-changes.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bug where syntactic transformations would be duplicated in some arithmetic expressions
 - Make token mints and accounts mutable in instruction contexts
 
+### Fixed
+
+- Error when using account key() as seed
+
 ## [0.2.4]
 
 ### Added

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -10,8 +10,7 @@ use crate::{
     match1,
 };
 use heck::ToPascalCase;
-use owo_colors::OwoColorize;
-use quote::{format_ident, quote};
+use quote::quote;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     rc::Rc,
@@ -625,23 +624,6 @@ impl Context {
                         value: value.into(),
                         name,
                     },
-                    // Special case: account key() is under account.borrow().__account__.key(), except in seeds
-                    // For seeds we just use the attribute as usual, eg account.key(), so only special case when not a seed
-                    // Note that this only applies to key, other attributes should use the generic ty case below
-                    Ty::Generic(TyName::Defined(_, DefinedType::Account), _)
-                        if !context_stack.has(&ExprContext::Seed) && name.eq("key") =>
-                    {
-                        let value = ExpressionObj::BorrowImmut(value.obj.into());
-                        let value = ExpressionObj::Attribute {
-                            value: value.into(),
-                            name: String::from("__account__"),
-                        };
-
-                        ExpressionObj::Attribute {
-                            value: value.into(),
-                            name,
-                        }
-                    }
                     ty => {
                         if ty.is_mut() {
                             // Methods of custom types are impl'd on `Mutable<T>`, not `T` - this

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -806,14 +806,7 @@ impl<'a> Context<'a> {
                                 vec![],
                                 Ty::Transformed(
                                     Ty::prelude(Prelude::Pubkey, vec![]).into(),
-                                    Transformation::new(|mut expr| {
-                                        let account = match1!(expr.obj, ExpressionObj::Call { function, .. } => *function);
-                                        let account = match1!(account.obj, ExpressionObj::Attribute { value, .. } => *value);
-
-                                        expr.obj = ExpressionObj::Rendered(quote! {
-                                            #account.borrow().__account__.key()
-                                        });
-
+                                    Transformation::new(|expr| { 
                                         Ok(Transformed::Expression(expr))
                                     })
                                 )

--- a/tests/compile-tests.sh
+++ b/tests/compile-tests.sh
@@ -11,3 +11,10 @@ do
     name="$(basename -- $f .py)"
     ${ROOT_DIR}/target/debug/seahorse compile $f > ${SCRIPT_DIR}/compiled-examples/$name.rs
 done
+
+for f in ${SCRIPT_DIR}/test-cases/*.py
+do
+    # get just the filename without directories or file extension (eg calculator)
+    name="$(basename -- $f .py)"
+    ${ROOT_DIR}/target/debug/seahorse compile $f > ${SCRIPT_DIR}/compiled-test-cases/$name.rs
+done

--- a/tests/compiled-test-cases/account_key.rs
+++ b/tests/compiled-test-cases/account_key.rs
@@ -7,7 +7,7 @@ pub mod program;
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unused_mut)]
-use crate::{assign, id, index_assign, seahorse_util::*};
+use crate::{id, seahorse_util::*};
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token::{self, Mint, Token, TokenAccount};
 use std::{cell::RefCell, rc::Rc};
@@ -222,6 +222,19 @@ pub mod seahorse_util {
     }
 
     #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    #[macro_export]
     macro_rules! assign {
         ($ lval : expr , $ rval : expr) => {{
             let temp = $rval;
@@ -239,6 +252,12 @@ pub mod seahorse_util {
             $lval[temp_idx] = temp_rval;
         };
     }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
 }
 
 #[program]

--- a/tests/compiled-test-cases/account_key.rs
+++ b/tests/compiled-test-cases/account_key.rs
@@ -1,0 +1,291 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{assign, id, index_assign, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+#[account]
+#[derive(Debug)]
+pub struct Another {
+    pub data: u8,
+}
+
+impl<'info, 'entrypoint> Another {
+    pub fn load(
+        account: &'entrypoint mut Box<Account<'info, Self>>,
+        programs_map: &'entrypoint ProgramsMap<'info>,
+    ) -> Mutable<LoadedAnother<'info, 'entrypoint>> {
+        let data = account.data;
+
+        Mutable::new(LoadedAnother {
+            __account__: account,
+            __programs__: programs_map,
+            data,
+        })
+    }
+
+    pub fn store(loaded: Mutable<LoadedAnother>) {
+        let mut loaded = loaded.borrow_mut();
+        let data = loaded.data;
+
+        loaded.__account__.data = data;
+    }
+}
+
+#[derive(Debug)]
+pub struct LoadedAnother<'info, 'entrypoint> {
+    pub __account__: &'entrypoint mut Box<Account<'info, Another>>,
+    pub __programs__: &'entrypoint ProgramsMap<'info>,
+    pub data: u8,
+}
+
+#[account]
+#[derive(Debug)]
+pub struct User {
+    pub data: u8,
+}
+
+impl<'info, 'entrypoint> User {
+    pub fn load(
+        account: &'entrypoint mut Box<Account<'info, Self>>,
+        programs_map: &'entrypoint ProgramsMap<'info>,
+    ) -> Mutable<LoadedUser<'info, 'entrypoint>> {
+        let data = account.data;
+
+        Mutable::new(LoadedUser {
+            __account__: account,
+            __programs__: programs_map,
+            data,
+        })
+    }
+
+    pub fn store(loaded: Mutable<LoadedUser>) {
+        let mut loaded = loaded.borrow_mut();
+        let data = loaded.data;
+
+        loaded.__account__.data = data;
+    }
+}
+
+#[derive(Debug)]
+pub struct LoadedUser<'info, 'entrypoint> {
+    pub __account__: &'entrypoint mut Box<Account<'info, User>>,
+    pub __programs__: &'entrypoint ProgramsMap<'info>,
+    pub data: u8,
+}
+
+pub fn ix_handler<'info>(
+    mut payer: SeahorseSigner<'info, '_>,
+    mut user: Mutable<LoadedUser<'info, '_>>,
+    mut another: Empty<Mutable<LoadedAnother<'info, '_>>>,
+) -> () {
+    let mut a = another.account.clone();
+
+    solana_program::msg!("{:?}", user.borrow().__account__.key());
+
+    solana_program::msg!("{}", user.borrow().data);
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("4SEMJzX6o2YQNws7yrsfUdjJCR4B5Z3GyR2Pj7UgzDy2");
+
+pub mod seahorse_util {
+    use super::*;
+
+    #[cfg(feature = "pyth-sdk-solana")]
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: Clone> Mutable<Vec<T>> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    impl<T: Clone, const N: usize> Mutable<[T; N]> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+}
+
+#[program]
+mod account_key {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    pub struct Ix<'info> {
+        #[account(mut)]
+        pub payer: Signer<'info>,
+        #[account(mut)]
+        pub user: Box<Account<'info, dot::program::User>>,
+        # [account (init , space = std :: mem :: size_of :: < dot :: program :: Another > () + 8 , payer = payer , seeds = [user . key () . as_ref ()] , bump)]
+        pub another: Box<Account<'info, dot::program::Another>>,
+        pub rent: Sysvar<'info, Rent>,
+        pub system_program: Program<'info, System>,
+    }
+
+    pub fn ix(ctx: Context<Ix>) -> Result<()> {
+        let mut programs = HashMap::new();
+
+        programs.insert(
+            "system_program",
+            ctx.accounts.system_program.to_account_info(),
+        );
+
+        let programs_map = ProgramsMap(programs);
+        let payer = SeahorseSigner {
+            account: &ctx.accounts.payer,
+            programs: &programs_map,
+        };
+
+        let user = dot::program::User::load(&mut ctx.accounts.user, &programs_map);
+        let another = Empty {
+            account: dot::program::Another::load(&mut ctx.accounts.another, &programs_map),
+            bump: ctx.bumps.get("another").map(|bump| *bump),
+        };
+
+        ix_handler(payer.clone(), user.clone(), another.clone());
+
+        dot::program::User::store(user);
+
+        dot::program::Another::store(another.account);
+
+        return Ok(());
+    }
+}
+

--- a/tests/test-cases/README.md
+++ b/tests/test-cases/README.md
@@ -1,0 +1,5 @@
+This directory contains compiler test cases that don't make sense as examples.
+
+They're tested in the same way as examples, but aren't intended to function as standalone example programs.
+
+This allows `examples` to double as useful documentation, without forcing us to make all test cases fit that format.

--- a/tests/test-cases/account_key.py
+++ b/tests/test-cases/account_key.py
@@ -1,0 +1,24 @@
+from seahorse.prelude import *
+
+declare_id('4SEMJzX6o2YQNws7yrsfUdjJCR4B5Z3GyR2Pj7UgzDy2')
+
+# This test case checks that we can use account attributes/functions in both seed and non-seed contexts
+# See https://github.com/ameliatastic/seahorse-lang/issues/62 for the original issue
+
+
+class User(Account):
+    data: u8
+
+
+class Another(Account):
+    data: u8
+
+
+@instruction
+def ix(payer: Signer, user: User, another: Empty[Another]):
+    # use key() as a seed
+    a = another.init(payer, seeds=[user.key()])
+    # check key() works correctly when not in a seed
+    print(user.key())
+    # check we can read arbitrary class fields of accounts
+    print(user.data)


### PR DESCRIPTION
The code we were generating was `user . borrow () . __account__ . key () . as_ref ()`. But `borrow()` didn't exist on the boxed accounts that we end up with in the accounts struct.

Instead we can just use `user.key().as_ref()` directly. 

Closes #62 