### PR TITLE
Refactor compile to work in wasm

### DIFF
--- a/src/core/compiler.rs
+++ b/src/core/compiler.rs
@@ -12,11 +12,12 @@ pub fn compile(
     program_name: String,
     working_dir: Option<PathBuf>,
 ) -> Result<GenerateOutput, CoreError> {
-    let python_source_ = python_source.clone();
-
-    let working_dir = working_dir.unwrap_or(
-        current_dir().map_err(|_| CoreError::make_raw("Could not get current directory", ""))?,
-    );
+    let working_dir = match working_dir {
+        Some(dir) => dir,
+        None => {
+            current_dir().map_err(|_| CoreError::make_raw("Could not get current directory", ""))?
+        }
+    };
 
     let parsed = parse(python_source.clone())?;
     let cleaned = clean(parsed, python_source)?;


### PR DESCRIPTION
`unwrap_or` eagerly evaluates the or case, so in WASM we were getting the "no current directory" error even when we pass Some `working_dir`, since `current_dir()` was returning an `Err`. 

By switching this to a match the `None` case is only evaluated if needed, and by passing `working_dir` we avoid evaluating `current_dir()`.