### PR TITLE
lol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Pubkey.find_program_address()` function, to find a PDA given a list of seeds and the program key
 
+### Fixed
+
+- `TokenMint.authority()` works
+
 ## [0.2.4]
 
 ### Added

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -950,7 +950,7 @@ impl BuiltinSource for Prelude {
                             let mint = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
 
                             expr.obj = ExpressionObj::Rendered(quote! {
-                                #mint.owner
+                                #mint.mint_authority.unwrap()
                             });
 
                             Ok(Transformed::Expression(expr))


### PR DESCRIPTION
Fixes `TokenMint.authority()`. Will cause a runtime error if the mint does not have an authority, that's a bug for another day.