### PR TITLE
Update token program API

### DIFF
--- a/data/const/seahorse_prelude.py
+++ b/data/const/seahorse_prelude.py
@@ -799,6 +799,9 @@ class TokenAccount(AccountWithKey):
     def amount(self) -> u64:
         """Get the amount of token stored in this account."""
 
+    def mint(self) -> Pubkey:
+        """Get the mint that this token account corresponds to."""
+
     def transfer(self, authority: AccountWithKey, to: 'TokenAccount', amount: u64, signer: List[Any] = None):
         """
         Transfer funds from this SPL token account to another.

--- a/data/const/seahorse_prelude.py
+++ b/data/const/seahorse_prelude.py
@@ -816,7 +816,16 @@ class TokenMint(AccountWithKey):
     """SPL token mint."""
 
     def authority(self) -> Pubkey:
-        """Get the owner of this token account."""
+        """Get the owner of this token mint."""
+
+    def freeze_authority(self) -> Pubkey:
+        """Get the freeze authority of this token mint."""
+
+    def decimals(self) -> u8:
+        """Get the number of decimals for this token."""
+
+    def supply(self) -> u64:
+        """Get the amount of this token that exists."""
 
     def mint(self, authority: AccountWithKey, to: TokenAccount, amount: u64, signer: List[Any] = None):
         """

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -958,6 +958,69 @@ impl BuiltinSource for Prelude {
                     ),
                 ),
             )),
+            // TokenMint.freeze_authority() -> Pubkey
+            (Self::TokenMint, "freeze_authority") => Some((
+                Ty::prelude(Self::TokenMint, vec![]),
+                Ty::new_function(
+                    vec![],
+                    Ty::Transformed(
+                        Ty::prelude(Self::Pubkey, vec![]).into(),
+                        Transformation::new(|mut expr| {
+                            let function =
+                                match1!(expr.obj, ExpressionObj::Call { function, .. } => function);
+                            let mint = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
+
+                            expr.obj = ExpressionObj::Rendered(quote! {
+                                #mint.freeze_authority.unwrap()
+                            });
+
+                            Ok(Transformed::Expression(expr))
+                        }),
+                    ),
+                ),
+            )),
+            // TokenMint.decimals() -> u8
+            (Self::TokenMint, "decimals") => Some((
+                Ty::prelude(Self::TokenMint, vec![]),
+                Ty::new_function(
+                    vec![],
+                    Ty::Transformed(
+                        Ty::prelude(Self::RustInt(false, 8), vec![]).into(),
+                        Transformation::new(|mut expr| {
+                            let function =
+                                match1!(expr.obj, ExpressionObj::Call { function, .. } => function);
+                            let mint = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
+
+                            expr.obj = ExpressionObj::Rendered(quote! {
+                                #mint.decimals
+                            });
+
+                            Ok(Transformed::Expression(expr))
+                        }),
+                    ),
+                ),
+            )),
+            // TokenMint.supply() -> u64
+            (Self::TokenMint, "supply") => Some((
+                Ty::prelude(Self::TokenMint, vec![]),
+                Ty::new_function(
+                    vec![],
+                    Ty::Transformed(
+                        Ty::prelude(Self::RustInt(false, 64), vec![]).into(),
+                        Transformation::new(|mut expr| {
+                            let function =
+                                match1!(expr.obj, ExpressionObj::Call { function, .. } => function);
+                            let mint = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
+
+                            expr.obj = ExpressionObj::Rendered(quote! {
+                                #mint.supply
+                            });
+
+                            Ok(Transformed::Expression(expr))
+                        }),
+                    ),
+                ),
+            )),
             // TokenAccount.transfer(authority = Cast(Account), to = TokenAccount, amount = u64, signer = List[Cast(Seed)]?) -> None
             (Self::TokenAccount, "transfer") => Some((
                 Ty::prelude(Self::TokenAccount, vec![]),


### PR DESCRIPTION
Noticed a few gaps in the token program's API, seemed like simple fixes that I might want in the future so I just did them. Just adds a few getter functions:

- `TokenAccount.mint()` to get the key of an account's mint,
- `TokenMint.freeze_authority()` to get the key of the token mint's freeze authority,
- `TokenMint.decimals()` to get the number of decimals for a token, and
- `TokenMint.supply()` to get a token's supply.

All were pretty simple, but I did of course check to make sure they compiled to the right thing.

Also there was an unrelated typo that I fixed, looks like a copy-paste error. Was just something small in the .py documentation file for `TokenMint`, no actual effect to anyone's code.