### PR TITLE
Expression context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bug when assigning to variables in deeper scopes
+- Bug that caused strings to not be converted to owned types in generate code
+- Bug that kept clones from appearing in generated code, leading to borrow checker errors
 
 ## [0.2.5]
 

--- a/src/bin/cli/build.rs
+++ b/src/bin/cli/build.rs
@@ -111,7 +111,11 @@ fn build_program(project_path: &PathBuf, program_name: String) -> Result<String,
                     "  - or as a Github issue (https://github.com/ameliatastic/seahorse-lang/issues).\n\n",
                     "Thanks!"
                 ).bold();
-                return Err(error_message(format!("{} failed:\n\n{}\n\n{}", cmd, report_note, stderr)).into());
+                return Err(error_message(format!(
+                    "{} failed:\n\n{}\n\n{}",
+                    cmd, report_note, stderr
+                ))
+                .into());
             }
 
             return Ok(anchor_output.stdout);

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -391,6 +391,13 @@ impl ExpressionObj {
         }
     }
 
+    pub fn is_mut_construct(&self) -> bool {
+        match self {
+            Self::Mutable(..) => true,
+            _ => false
+        }
+    }
+
     pub fn without_borrows(self) -> Self {
         match self {
             Self::BinOp { left, op, right } => Self::BinOp {

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 
-use super::{super::generate::Feature, builtin::{prelude::MethodType, pyth::ExprContext}, check::Ty};
+use super::{super::generate::Feature, builtin::{prelude::MethodType, pyth::{ExprContext, ExprContextStack}}, check::Ty};
 use crate::core::Tree;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -294,8 +294,8 @@ impl TypedExpression {
     }
 
     /// Add a move to the expression, if appropriate to do so.
-    pub fn moved(mut self, context_stack: &Vec<ExprContext>) -> Self {
-        if !context_stack.contains(&ExprContext::Directive) && !context_stack.contains(&ExprContext::Seed) {
+    pub fn moved(mut self, context_stack: &ExprContextStack) -> Self {
+        if !context_stack.has_any(&[ExprContext::Directive, ExprContext::Seed]) {
             self.obj = ExpressionObj::Move(self.obj.into());
         }
 

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -1,6 +1,13 @@
 use proc_macro2::TokenStream;
 
-use super::{super::generate::Feature, builtin::{prelude::MethodType, pyth::{ExprContext, ExprContextStack}}, check::Ty};
+use super::{
+    super::generate::Feature,
+    builtin::{
+        prelude::MethodType,
+        pyth::{ExprContext, ExprContextStack},
+    },
+    check::Ty,
+};
 use crate::core::Tree;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -405,8 +412,11 @@ impl ExpressionObj {
     /// value (attributes or indices).
     pub fn is_owned(&self) -> bool {
         match self {
-            Self::Attribute { .. } | Self::Id(..) | Self::Index { .. } | Self::TupleIndex { .. } => true,
-            _ => false
+            Self::Attribute { .. }
+            | Self::Id(..)
+            | Self::Index { .. }
+            | Self::TupleIndex { .. } => true,
+            _ => false,
         }
     }
 

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -928,6 +928,10 @@ impl<'a> Context<'a> {
             // Might be multiple transformations
             self.transform(expression, loc, context_stack)
         } else {
+            if expression.ty.is_mut() && !context_stack.contains(&ExprContext::LVal) {
+                expression.obj = ExpressionObj::Move(expression.obj.into());
+            }
+
             Ok(expression)
         }
     }

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -72,7 +72,8 @@ pub struct Transformation {
 pub enum ExprContext {
     LVal,
     Seed,
-    Directive
+    Directive,
+    Assert
 }
 
 impl Transformation {
@@ -410,7 +411,7 @@ impl<'a> Context<'a> {
             ast::StatementObj::Pass => Statement::Noop,
             ast::StatementObj::Assert { test, msg } => Statement::AnchorRequire {
                 cond: self.build_expression(test, vec![])?,
-                msg: self.build_expression(msg.unwrap(), vec![])?,
+                msg: self.build_expression(msg.unwrap(), vec![ExprContext::Assert])?,
             },
             ast::StatementObj::Assign { target, value } => {
                 let assign = self.assign_order.pop_front().unwrap();
@@ -758,7 +759,7 @@ impl<'a> Context<'a> {
                 }
             }
             ast::ExpressionObj::Str(s) => {
-                if context_stack.contains(&ExprContext::Seed) || context_stack.contains(&ExprContext::Directive) {
+                if context_stack.contains(&ExprContext::Seed) || context_stack.contains(&ExprContext::Directive)  || context_stack.contains(&ExprContext::Assert){
                     ExpressionObj::Literal(Literal::Str(s))
                 } else {
                     ExpressionObj::Rendered(quote! {

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -68,7 +68,7 @@ pub struct Transformation {
     pub context: Option<ExprContext>
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ExprContext {
     LVal,
     Seed,
@@ -764,7 +764,15 @@ impl<'a> Context<'a> {
                     Mutable::new(#block)
                 })
             }
-            ast::ExpressionObj::Str(s) => ExpressionObj::Literal(Literal::Str(s)),
+            ast::ExpressionObj::Str(s) => {
+                if context_stack.contains(&ExprContext::Seed) || context_stack.contains(&ExprContext::Directive) {
+                    ExpressionObj::Literal(Literal::Str(s))
+                } else {
+                    ExpressionObj::Rendered(quote! {
+                        #s.to_string()
+                    })
+                }
+            },
             ast::ExpressionObj::FStr { parts } => {
                 let mut format = String::from("");
                 let mut parts_ = vec![];

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -411,7 +411,6 @@ impl BuiltinSource for Prelude {
                         ),
                         (
                             "seeds",
-                            // TODO maybe move context addition to here?
                             Ty::new_list(Ty::Cast(Ty::prelude(Self::Seed, vec![]).into())),
                             ParamType::Optional,
                         ),

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -411,6 +411,7 @@ impl BuiltinSource for Prelude {
                         ),
                         (
                             "seeds",
+                            // TODO maybe move context addition to here?
                             Ty::new_list(Ty::Cast(Ty::prelude(Self::Seed, vec![]).into())),
                             ParamType::Optional,
                         ),
@@ -447,7 +448,7 @@ impl BuiltinSource for Prelude {
                     ],
                     Ty::Transformed(
                         Ty::Anonymous(0).into(),
-                        Transformation::new(|mut expr| {
+                        Transformation::new_with_context(|mut expr, _| {
                             let (function, args) = match1!(expr.obj, ExpressionObj::Call { function, args } => (function, args));
                             let empty = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
                             let name = match1!(&empty.obj, ExpressionObj::Id(var) => var.clone());
@@ -572,7 +573,7 @@ impl BuiltinSource for Prelude {
                                 name,
                                 annotation,
                             })
-                        }),
+                        }, Some(ExprContext::Seed)),
                     ),
                 ),
             )),

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -447,130 +447,137 @@ impl BuiltinSource for Prelude {
                     ],
                     Ty::Transformed(
                         Ty::Anonymous(0).into(),
-                        Transformation::new_with_context(|mut expr, _| {
-                            let (function, args) = match1!(expr.obj, ExpressionObj::Call { function, args } => (function, args));
-                            let empty = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
-                            let name = match1!(&empty.obj, ExpressionObj::Id(var) => var.clone());
-                            let mut args = args.into_iter();
+                        Transformation::new_with_context(
+                            |mut expr, _| {
+                                let (function, args) = match1!(expr.obj, ExpressionObj::Call { function, args } => (function, args));
+                                let empty = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
+                                let name =
+                                    match1!(&empty.obj, ExpressionObj::Id(var) => var.clone());
+                                let mut args = args.into_iter();
 
-                            let mut annotation = AccountAnnotation::new();
-                            annotation.is_mut = false;
-                            annotation.init = true;
+                                let mut annotation = AccountAnnotation::new();
+                                annotation.is_mut = false;
+                                annotation.init = true;
 
-                            let payer = args.next().unwrap();
-                            let seeds = args.next().unwrap().optional();
+                                let payer = args.next().unwrap();
+                                let seeds = args.next().unwrap().optional();
 
-                            let mint = args.next().unwrap().optional();
-                            let authority = args.next().unwrap().optional();
-                            let decimals = args.next().unwrap().optional();
-                            let associated = match args.next().unwrap().obj {
-                                ExpressionObj::Literal(Literal::Bool(associated)) => {
-                                    Some(associated)
-                                }
-                                ExpressionObj::Placeholder => None,
-                                _ => {
-                                    return Err(CoreError::make_raw(
+                                let mint = args.next().unwrap().optional();
+                                let authority = args.next().unwrap().optional();
+                                let decimals = args.next().unwrap().optional();
+                                let associated = match args.next().unwrap().obj {
+                                    ExpressionObj::Literal(Literal::Bool(associated)) => {
+                                        Some(associated)
+                                    }
+                                    ExpressionObj::Placeholder => None,
+                                    _ => {
+                                        return Err(CoreError::make_raw(
                                         "invalid argument to Empty.init()",
                                         "Hint: if you provide a value for \"associated\", it must be a boolean literal."
                                     ));
-                                }
-                            };
-                            let space = args.next().unwrap().optional();
-                            let padding = args.next().unwrap().optional();
+                                    }
+                                };
+                                let space = args.next().unwrap().optional();
+                                let padding = args.next().unwrap().optional();
 
-                            annotation.payer = Some(payer);
-                            annotation.seeds = seeds.map(|seeds| {
-                                let seeds = match1!(seeds.obj, ExpressionObj::Vec(list) => list);
-                                seeds
-                            });
+                                annotation.payer = Some(payer);
+                                annotation.seeds = seeds.map(|seeds| {
+                                    let seeds =
+                                        match1!(seeds.obj, ExpressionObj::Vec(list) => list);
+                                    seeds
+                                });
 
-                            match &expr.ty {
-                                Ty::Generic(name, _) => match name {
-                                    TyName::Defined(_, DefinedType::Account) => {
-                                        if mint.is_some()
-                                            || authority.is_some()
-                                            || decimals.is_some()
-                                            || associated.is_some()
-                                        {
-                                            return Err(CoreError::make_raw(
+                                match &expr.ty {
+                                    Ty::Generic(name, _) => match name {
+                                        TyName::Defined(_, DefinedType::Account) => {
+                                            if mint.is_some()
+                                                || authority.is_some()
+                                                || decimals.is_some()
+                                                || associated.is_some()
+                                            {
+                                                return Err(CoreError::make_raw(
                                                 "invalid argument to Empty.init() for a program account",
                                                 "Hint: you can only pass in a payer and optionally a list of seeds."
                                             ));
-                                        }
+                                            }
 
-                                        if space.is_some() && padding.is_some() {
-                                            return Err(CoreError::make_raw(
+                                            if space.is_some() && padding.is_some() {
+                                                return Err(CoreError::make_raw(
                                                 "invalid argument to Empty.init() for a program account",
                                                 "Hint: you can only pass one of space and padding",
                                             ));
+                                            }
+
+                                            annotation.space = space;
+                                            annotation.padding = padding;
                                         }
 
-                                        annotation.space = space;
-                                        annotation.padding = padding;
-                                    }
-
-                                    TyName::Builtin(Builtin::Prelude(Self::TokenMint)) => {
-                                        if mint.is_some()
-                                            || authority.is_none()
-                                            || decimals.is_none()
-                                            || associated.is_some()
-                                            || space.is_some()
-                                        {
-                                            return Err(CoreError::make_raw(
+                                        TyName::Builtin(Builtin::Prelude(Self::TokenMint)) => {
+                                            if mint.is_some()
+                                                || authority.is_none()
+                                                || decimals.is_none()
+                                                || associated.is_some()
+                                                || space.is_some()
+                                            {
+                                                return Err(CoreError::make_raw(
                                                 "invalid argument to Empty[TokenMint].init()",
                                                 "Hint: you can only pass in a payer, an authority, a number of decimals, and optionally a list of seeds."
                                             ));
-                                        }
+                                            }
 
-                                        annotation.mint_authority = authority;
-                                        annotation.mint_decimals = decimals;
-                                    }
-                                    TyName::Builtin(Builtin::Prelude(Self::TokenAccount)) => {
-                                        if mint.is_none()
-                                            || authority.is_none()
-                                            || decimals.is_some()
-                                            || space.is_some()
-                                        {
-                                            return Err(CoreError::make_raw(
+                                            annotation.mint_authority = authority;
+                                            annotation.mint_decimals = decimals;
+                                        }
+                                        TyName::Builtin(Builtin::Prelude(Self::TokenAccount)) => {
+                                            if mint.is_none()
+                                                || authority.is_none()
+                                                || decimals.is_some()
+                                                || space.is_some()
+                                            {
+                                                return Err(CoreError::make_raw(
                                                 "invalid argument to Empty[TokenAccount].init()",
                                                 "Hint: you can only pass in a payer, an authority, a mint, and optionally a list of seeds."
                                             ));
-                                        }
+                                            }
 
-                                        if annotation.seeds.is_some() && associated == Some(true) {
-                                            return Err(CoreError::make_raw(
+                                            if annotation.seeds.is_some()
+                                                && associated == Some(true)
+                                            {
+                                                return Err(CoreError::make_raw(
                                                 "invalid argument to Empty[TokenAccount].init()",
                                                 "Hint: you may not initialize an associated token account with seeds."
                                             ));
-                                        }
+                                            }
 
-                                        annotation.token_authority = authority;
-                                        annotation.token_mint = mint;
+                                            annotation.token_authority = authority;
+                                            annotation.token_mint = mint;
 
-                                        if associated == Some(true) {
-                                            annotation.is_associated = true;
+                                            if associated == Some(true) {
+                                                annotation.is_associated = true;
+                                            }
                                         }
-                                    }
-                                    _ => {
-                                        return Err(CoreError::make_raw(
+                                        _ => {
+                                            return Err(CoreError::make_raw(
                                             format!("could not initialize account type \"{}\"", expr.ty),
                                             "Help: you can only initialize program accounts (owned by your program), SPL token mints, and SPL token accounts."
                                         ));
-                                    }
-                                },
-                                _ => panic!(),
-                            }
+                                        }
+                                    },
+                                    _ => panic!(),
+                                }
 
-                            expr.obj = ExpressionObj::Rendered(quote! {
-                                #empty.account.clone()
-                            });
+                                expr.obj = ExpressionObj::Rendered(quote! {
+                                    #empty.account.clone()
+                                });
 
-                            Ok(Transformed::AccountInit {
-                                expr,
-                                name,
-                                annotation,
-                            })
-                        }, Some(ExprContext::Seed)),
+                                Ok(Transformed::AccountInit {
+                                    expr,
+                                    name,
+                                    annotation,
+                                })
+                            },
+                            Some(ExprContext::Seed),
+                        ),
                     ),
                 ),
             )),

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -480,8 +480,6 @@ impl BuiltinSource for Prelude {
 
                             annotation.payer = Some(payer);
                             annotation.seeds = seeds.map(|seeds| {
-                                let seeds =
-                                    match1!(seeds.obj, ExpressionObj::Mutable(list) => *list);
                                 let seeds = match1!(seeds.obj, ExpressionObj::Vec(list) => list);
                                 seeds
                             });

--- a/src/core/compile/builtin/python.rs
+++ b/src/core/compile/builtin/python.rs
@@ -364,7 +364,7 @@ impl BuiltinSource for Python {
                         }.into();
 
                         let elem = match return_ty {
-                            Ty::Transformed(_, transformation) => match transformation.0(call)? {
+                            Ty::Transformed(_, transformation) => match (transformation.function)(call, &vec![])? {
                                 Transformed::Expression(expression) => expression,
                                 _ => {
                                     return Err(CoreError::make_raw(
@@ -419,7 +419,7 @@ impl BuiltinSource for Python {
                         }.into();
 
                         let elem = match return_ty {
-                            Ty::Transformed(_, transformation) => match transformation.0(call)? {
+                            Ty::Transformed(_, transformation) => match (transformation.function)(call, &vec![])? {
                                 Transformed::Expression(expression) => expression,
                                 _ => {
                                     return Err(CoreError::make_raw(

--- a/src/core/compile/builtin/python.rs
+++ b/src/core/compile/builtin/python.rs
@@ -364,7 +364,7 @@ impl BuiltinSource for Python {
                         }.into();
 
                         let elem = match return_ty {
-                            Ty::Transformed(_, transformation) => match (transformation.function)(call, &vec![])? {
+                            Ty::Transformed(_, transformation) => match (transformation.function)(call, &vec![].into())? {
                                 Transformed::Expression(expression) => expression,
                                 _ => {
                                     return Err(CoreError::make_raw(
@@ -419,7 +419,7 @@ impl BuiltinSource for Python {
                         }.into();
 
                         let elem = match return_ty {
-                            Ty::Transformed(_, transformation) => match (transformation.function)(call, &vec![])? {
+                            Ty::Transformed(_, transformation) => match (transformation.function)(call, &vec![].into())? {
                                 Transformed::Expression(expression) => expression,
                                 _ => {
                                     return Err(CoreError::make_raw(

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -706,11 +706,16 @@ impl<'a> Context<'a> {
     }
 
     /// Declare a target, creating a new type parameter for it.
-    /// 
+    ///
     /// Also builds a list of the variable names that get declared by this
     /// target. Declarations can happen due to the creation of a new free type,
     /// or the modification of an existing type (according to the scoping rules).
-    fn declare_target(&mut self, target: &Target, force_declare: bool, declarations: &mut Vec<String>) -> CResult<usize> {
+    fn declare_target(
+        &mut self,
+        target: &Target,
+        force_declare: bool,
+        declarations: &mut Vec<String>,
+    ) -> CResult<usize> {
         match target {
             Target::Var(var) => {
                 if !force_declare {
@@ -730,7 +735,13 @@ impl<'a> Context<'a> {
             Target::Tuple(tuple) => {
                 let params = tuple
                     .iter()
-                    .map(|target| Ok(Ty::Param(self.declare_target(target, force_declare, declarations)?)))
+                    .map(|target| {
+                        Ok(Ty::Param(self.declare_target(
+                            target,
+                            force_declare,
+                            declarations,
+                        )?))
+                    })
                     .collect::<Result<Vec<_>, CoreError>>()?;
 
                 let param = self.new_ty(Ty::python(Python::Tuple, params));
@@ -1090,9 +1101,13 @@ impl<'a> Context<'a> {
                         self.check_expr(ty.clone(), value)?;
 
                         let mut declarations = vec![];
-                        let param_target = self.declare_target(&target, false, &mut declarations)?;
+                        let param_target =
+                            self.declare_target(&target, false, &mut declarations)?;
                         // Infallible
-                        if let Assign::Declare { ref mut undeclared, .. } = self.assign_order[assign_i] {
+                        if let Assign::Declare {
+                            ref mut undeclared, ..
+                        } = self.assign_order[assign_i]
+                        {
                             *undeclared = declarations;
                         }
 
@@ -1118,7 +1133,10 @@ impl<'a> Context<'a> {
                     let mut declarations = vec![];
                     let param_target = self.declare_target(&target, false, &mut declarations)?;
                     // Infallible
-                    if let Assign::Declare { ref mut undeclared, .. } = self.assign_order[assign_i] {
+                    if let Assign::Declare {
+                        ref mut undeclared, ..
+                    } = self.assign_order[assign_i]
+                    {
                         *undeclared = declarations;
                     }
 
@@ -1363,7 +1381,8 @@ impl<'a> Context<'a> {
                             match as_assignment_target(target) {
                                 Some(target) => {
                                     // TODO not dry, copy-pasted from StatementObj::For
-                                    let param_target = self.declare_target(&target, true, &mut vec![])?;
+                                    let param_target =
+                                        self.declare_target(&target, true, &mut vec![])?;
                                     self.assign_order.push(Assign::Declare {
                                         undeclared: vec![],
                                         target,

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -836,7 +836,7 @@ impl ToTokens for Statement {
                         } else {
                             quote! { let #target = #value; }
                         }
-                    },
+                    }
                     LetTarget::Tuple(..) => {
                         let target = target.as_immut();
 
@@ -1041,7 +1041,7 @@ impl ToTokens for ExpressionObj {
                 } else {
                     quote! { #value }
                 }
-            },
+            }
             Self::BorrowMut(value) => quote! { #value . borrow_mut() },
             Self::BorrowImmut(value) => quote! { #value . borrow() },
             Self::Mutable(value) => {

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -1033,7 +1033,15 @@ impl ToTokens for ExpressionObj {
             Self::Literal(literal) => quote! { #literal },
             Self::Block(block) => quote! { #block },
             Self::Ref(value) => quote! { (& #value) },
-            Self::Move(value) => quote! { #value . clone() },
+            Self::Move(value) => {
+                // If we're trying to move some data, we need to explicitly
+                // clone it if the type is not `Copy` and the data is owned
+                if !value.ty.is_copy() && value.obj.is_owned() {
+                    quote! { #value . clone() }
+                } else {
+                    quote! { #value }
+                }
+            },
             Self::BorrowMut(value) => quote! { #value . borrow_mut() },
             Self::BorrowImmut(value) => quote! { #value . borrow() },
             Self::Mutable(value) => {

--- a/tests/compiled-examples/calculator.rs
+++ b/tests/compiled-examples/calculator.rs
@@ -76,7 +76,7 @@ pub fn do_operation_handler<'info>(
     mut num: i64,
 ) -> () {
     if !(owner.key() == calculator.borrow().owner) {
-        panic!("This is not your calculator!".to_string());
+        panic!("This is not your calculator!");
     }
 
     if op == Operation::ADD {
@@ -129,7 +129,7 @@ pub fn reset_calculator_handler<'info>(
     );
 
     if !(owner.key() == calculator.borrow().owner) {
-        panic!("This is not your calculator!".to_string());
+        panic!("This is not your calculator!");
     }
 
     assign!(calculator.borrow_mut().display, 0);

--- a/tests/compiled-examples/calculator.rs
+++ b/tests/compiled-examples/calculator.rs
@@ -76,7 +76,7 @@ pub fn do_operation_handler<'info>(
     mut num: i64,
 ) -> () {
     if !(owner.key() == calculator.borrow().owner) {
-        panic!("This is not your calculator!");
+        panic!("This is not your calculator!".to_string());
     }
 
     if op == Operation::ADD {
@@ -124,12 +124,12 @@ pub fn reset_calculator_handler<'info>(
     solana_program::msg!(
         "{:?} {} {:?}",
         owner.key(),
-        "is resetting a calculator",
+        "is resetting a calculator".to_string(),
         calculator.borrow().__account__.key()
     );
 
     if !(owner.key() == calculator.borrow().owner) {
-        panic!("This is not your calculator!");
+        panic!("This is not your calculator!".to_string());
     }
 
     assign!(calculator.borrow_mut().display, 0);

--- a/tests/compiled-examples/event.rs
+++ b/tests/compiled-examples/event.rs
@@ -45,7 +45,7 @@ pub fn send_event_handler<'info>(
     mut data: u8,
     mut title: String,
 ) -> () {
-    let mut event = HelloEvent::__new__(data, title, sender.key());
+    let mut event = HelloEvent::__new__(data.clone(), title.clone(), sender.key());
 
     event.__emit__();
 }

--- a/tests/compiled-examples/hello.rs
+++ b/tests/compiled-examples/hello.rs
@@ -78,7 +78,7 @@ pub fn say_hello_handler<'info>(
                 to: user_acc.to_account_info(),
             },
             &[Mutable::new(vec![
-                "hello".as_bytes().as_ref(),
+                "hello".to_string().as_bytes().as_ref(),
                 bump.to_le_bytes().as_ref(),
             ])
             .borrow()

--- a/tests/compiled-examples/hello.rs
+++ b/tests/compiled-examples/hello.rs
@@ -75,7 +75,7 @@ pub fn say_hello_handler<'info>(
             token::MintTo {
                 mint: mint.to_account_info(),
                 authority: hello.borrow().__account__.to_account_info(),
-                to: user_acc.to_account_info(),
+                to: user_acc.clone().to_account_info(),
             },
             &[Mutable::new(vec![
                 "hello".to_string().as_bytes().as_ref(),


### PR DESCRIPTION
Putting some thoughts into a branch for how to tackle this problem. [Context.](https://github.com/ameliatastic/seahorse-lang/pull/66#issuecomment-1334535626)

Basically, the compiler needs a way for _context_ to be passed down to expressions. When the **build** stage is run and a Rust-like AST is generated, the entire tree is built from the leaves up. This means that expressions like `a = f(x, y)` will first build the syntax tree component for `a`, `x`, then `y`, then combine those to make `f(x, y)`, then combine those to make `a = f(x, y)`.

This introduces a small problem: the innermost expressions have no way of knowing the context that they're being created in. An example that's been resolved in a somewhat hacky way: a very simple assignment statement like

```py
x.a = y.b
```

needs to be turned into something like

```rs
x.borrow_mut().a = y.borrow().b;
```

due to how mutability is handled. Even though syntactically, the (Python) expressions on the left and right are exactly the same, they need to generated different (Rust) expressions! Right now this is handled by just traversing the LHS a second time and making all of the borrows mutable borrows, but this could easily lead to unforeseen problems. It would be much cleaner to just generate the right code the first time.

However,  getting there is a challenge, because this involves actually changing the compiler, and maybe changing it significantly. On this PR I'll be looking trying to figure out a good way of solving the problem. Any outside help would be greatly appreciated. Thanks!

Closes #81 
Closes #72