### PR TITLE
Update pyth-sdk-solana to 0.7.0 for compatibility with Anchor 0.26.0

### DIFF
--- a/data/const/seahorse_pyth.py
+++ b/data/const/seahorse_pyth.py
@@ -14,7 +14,7 @@ class Price:
     """
     Pyth `Price` struct with some extra convenience functions. You can access the raw data of the struct through its fields.
 
-    "A price with a degree of uncertainty, represented as a price +- a confidence interval." (from https://docs.rs/pyth-sdk-solana/0.6.1/pyth_sdk_solana/struct.Price.html)
+    "A price with a degree of uncertainty, represented as a price +- a confidence interval." (from https://docs.rs/pyth-sdk-solana/0.7.0/pyth_sdk_solana/struct.Price.html)
     """
 
     price: i64
@@ -24,16 +24,18 @@ class Price:
     def num(self) -> f64:
         """Simply get price as a floating-point number. Does not take confidence into account, instead reporting the average estimated price."""
 
+
 class PriceFeed:
     """
     Pyth `PriceFeed` struct with some extra convience functions.
 
-    "Represents a current aggregation price from pyth publisher feeds." (from https://docs.rs/pyth-sdk-solana/0.6.1/pyth_sdk_solana/struct.PriceFeed.html)
+    "Represents a current aggregation price from pyth publisher feeds." (from https://docs.rs/pyth-sdk-solana/0.7.0/pyth_sdk_solana/struct.PriceFeed.html)
     """
 
     def get_price(self) -> Price:
         """Get the price. Throws an error if the product is not currently trading."""
         pass
+
 
 class PriceAccount(AccountWithKey):
     """Raw Pyth price account. Needs to be validated before use."""

--- a/src/bin/cli/init.rs
+++ b/src/bin/cli/init.rs
@@ -209,7 +209,7 @@ pub fn init(args: InitArgs) -> Result<(), Box<dyn Error>> {
             let mut pyth = InlineTable::new();
             pyth.insert(
                 "version",
-                Value::String(Formatted::new("0.6.1".to_string())),
+                Value::String(Formatted::new("0.7.0".to_string())),
             );
             pyth.insert("optional", Value::Boolean(Formatted::new(true)));
             cargo["dependencies"]["pyth-sdk-solana"] = Item::Value(Value::InlineTable(pyth));


### PR DESCRIPTION
- Seahorse actually uses whichever version of Anchor you have installed/active, so no need to explicitly bump it
- But there was a dependency clash between pyth-sdk-solana 0.6.1 and Anchor 0.26.0 (on solana-program-library) causing a compile error on `seahorse build`
- Bumping to 0.7.0 works with both Anchor 0.25.0 and Anchor 0.26.0
- Also tested with all examples on Anchor 0.26.0

Closes #80 