### PR TITLE
Add constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Constants may be defined in source files
+
 ## [0.2.6]
 
 ### Added

--- a/examples/constants.py
+++ b/examples/constants.py
@@ -1,0 +1,25 @@
+# constants
+# Built with Seahorse v0.1.0
+#
+# Demonstrate simple use of constants
+
+from seahorse.prelude import *
+
+declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
+
+
+MIN = 2
+MAX = 7
+RANGE = MAX - MIN
+
+MESSAGE = 'Hello constants'
+
+
+@instruction
+def use_constants(signer: Signer):
+    print(MESSAGE)
+    
+    for i in range(MIN, MAX):
+        print('Step:', i)
+    
+    print('Range:', RANGE)

--- a/src/core/clean/ast.rs
+++ b/src/core/clean/ast.rs
@@ -25,6 +25,10 @@ pub enum TopLevelStatementObj {
         path: Vec<String>,
         symbols: Vec<ImportSymbol>,
     },
+    Constant {
+        name: String,
+        value: Expression,
+    },
     ClassDef {
         name: String,
         body: Vec<ClassDefStatement>,

--- a/src/core/clean/mod.rs
+++ b/src/core/clean/mod.rs
@@ -278,12 +278,12 @@ impl TryInto<TopLevelStatement> for WithSrc<py::Statement> {
                 if targets.len() != 1 {
                     Err(Error::InvalidConstant)
                 } else {
-                    let target = WithSrc::new(&src, targets.into_iter().next().unwrap()).try_into()?;
+                    let target =
+                        WithSrc::new(&src, targets.into_iter().next().unwrap()).try_into()?;
 
                     if !validate_constant(&value) {
                         Err(Error::NonconstantConstant)
-                    }
-                    else if let Located(_, ExpressionObj::Id(name)) = target {
+                    } else if let Located(_, ExpressionObj::Id(name)) = target {
                         Ok(TopLevelStatementObj::Constant {
                             name,
                             value: WithSrc::new(&src, value).try_into()?,
@@ -293,9 +293,7 @@ impl TryInto<TopLevelStatement> for WithSrc<py::Statement> {
                     }
                 }
             }
-            py::StatementType::AnnAssign { .. } => {
-                Err(Error::InvalidConstant)
-            }
+            py::StatementType::AnnAssign { .. } => Err(Error::InvalidConstant),
             py::StatementType::ClassDef {
                 name,
                 body,

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -41,7 +41,7 @@ pub enum Directive {
 #[derive(Clone, Debug)]
 pub struct Constant {
     pub name: String,
-    pub value: TypedExpression
+    pub value: TypedExpression,
 }
 
 /// A type definition.

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -39,7 +39,10 @@ pub enum Directive {
 
 /// A `const` declaration.
 #[derive(Clone, Debug)]
-pub struct Constant;
+pub struct Constant {
+    pub name: String,
+    pub value: TypedExpression
+}
 
 /// A type definition.
 #[derive(Clone, Debug)]

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -182,7 +182,7 @@ impl From<TypecheckOutput> for Context {
             ix_context: None,
             directives: None,
             expr_order: typecheck.expr_order.into(),
-            assign_order: typecheck.assign_order.into()
+            assign_order: typecheck.assign_order.into(),
         }
     }
 }

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -974,7 +974,9 @@ impl<'a> Context<'a> {
                     attr_ty
                 }
             }
-            Signature::Class(ClassSignature::Enum(..)) | Signature::Function(..) | Signature::Constant(..) => None,
+            Signature::Class(ClassSignature::Enum(..))
+            | Signature::Function(..)
+            | Signature::Constant(..) => None,
             Signature::Builtin(builtin) => builtin.attr(attr),
         }
     }
@@ -1659,11 +1661,14 @@ impl<'a> Context<'a> {
     /// Check a constant expansion.
     fn check_constant(&mut self, expr_ty: Ty, expansion: &ast::Expression) -> CResult<Ty> {
         let ty = self.check_expr_independent(expr_ty, expansion)?;
-        let ty = Ty::Transformed(ty.into(), Transformation::new(|mut expr| {
-            let name = expr.obj;
-            expr.obj = ExpressionObj::Rendered(quote! { #name !() });
-            Ok(Transformed::Expression(expr))
-        }));
+        let ty = Ty::Transformed(
+            ty.into(),
+            Transformation::new(|mut expr| {
+                let name = expr.obj;
+                expr.obj = ExpressionObj::Rendered(quote! { #name !() });
+                Ok(Transformed::Expression(expr))
+            }),
+        );
 
         return Ok(ty);
     }

--- a/src/core/compile/check/mod.rs
+++ b/src/core/compile/check/mod.rs
@@ -16,6 +16,7 @@ use crate::core::{
 use crate::match1;
 use quote::quote;
 use std::collections::HashMap;
+use std::mem::replace;
 
 use super::builtin::prelude::Transformed;
 
@@ -385,6 +386,7 @@ impl std::fmt::Display for TyName {
 /// "" in the `Checked` output.
 #[derive(Clone, Debug)]
 pub enum FinalContext {
+    Constant(TypecheckOutput),
     Class(HashMap<String, TypecheckOutput>),
     Function(TypecheckOutput),
     Directives(Vec<(ast::Expression, TypecheckOutput)>),
@@ -573,6 +575,19 @@ impl<'a> Context<'a> {
         return Ok(context.into());
     }
 
+    fn typecheck_constant(
+        constant: &ast::Expression,
+        sign_output: &'a SignOutput,
+        abs: &'a Vec<String>,
+    ) -> CResult<TypecheckOutput> {
+        let mut context = Self::new(sign_output, abs);
+
+        let ty = Ty::Param(context.free());
+        context.check_expr(ty, constant)?;
+
+        return Ok(context.into());
+    }
+
     /// Add a new free variable, returning the new type parameter.
     fn free(&mut self) -> usize {
         let param = self.types.len();
@@ -752,7 +767,7 @@ impl<'a> Context<'a> {
     }
 
     /// Get the type of an attribute of a type.
-    fn attr(&self, t: Ty, attr: &String) -> Option<(Ty, Ty)> {
+    fn attr(&mut self, t: Ty, attr: &String) -> Option<(Ty, Ty)> {
         match t.clone() {
             Ty::Param(i) => self.attr(self.types[i].clone(), attr),
             Ty::IntParam(i) => self.attr(self.types[i].clone(), attr),
@@ -859,6 +874,14 @@ impl<'a> Context<'a> {
                     Some(Export::Item(..)) => {
                         match self.sign_output.tree.get_leaf(&abs).unwrap().get(attr) {
                             // wow this got ugly
+                            Some(Signature::Constant(expansion)) => {
+                                let ty = Ty::Param(self.free());
+
+                                Some((
+                                    Ty::Anonymous(0),
+                                    self.check_constant(ty, expansion).ok()?
+                                ))
+                            },
                             Some(Signature::Class(ClassSignature::Struct(StructSignature {
                                 is_account: true,
                                 ..
@@ -927,7 +950,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    fn defined_attr(&self, path: &Vec<String>, attr: &String) -> Option<(Ty, Ty)> {
+    fn defined_attr(&mut self, path: &Vec<String>, attr: &String) -> Option<(Ty, Ty)> {
         match self.sign_output.tree.get_leaf_ext(path).unwrap() {
             Signature::Class(ClassSignature::Struct(sig)) => {
                 if sig.fields.contains_key(attr) {
@@ -951,8 +974,7 @@ impl<'a> Context<'a> {
                     attr_ty
                 }
             }
-            Signature::Class(ClassSignature::Enum(..)) => None,
-            Signature::Function(..) => None,
+            Signature::Class(ClassSignature::Enum(..)) | Signature::Function(..) | Signature::Constant(..) => None,
             Signature::Builtin(builtin) => builtin.attr(attr),
         }
     }
@@ -984,7 +1006,7 @@ impl<'a> Context<'a> {
                         None
                     }
                 }
-                Signature::Function(..) => None,
+                Signature::Function(..) | Signature::Constant(..) => None,
                 Signature::Builtin(builtin) => {
                     builtin.static_attr(attr).map(|t| (Ty::Anonymous(0), t))
                 }
@@ -1447,6 +1469,10 @@ impl<'a> Context<'a> {
                     Some(Export::Import(Located(loc, import))) => match import {
                         ImportObj::SymbolPath(path) => {
                             match self.sign_output.tree.get_leaf_ext(path) {
+                                Some(Signature::Constant(expansion)) => {
+                                    let ty = self.check_constant(expr_ty.clone(), expansion)?;
+                                    self.unify(expr_ty, ty, loc)?
+                                }
                                 Some(Signature::Builtin(builtin)) => {
                                     let ty = self.deanonymize(builtin.ty());
                                     self.unify(expr_ty, ty, loc)?
@@ -1522,6 +1548,10 @@ impl<'a> Context<'a> {
                         path.push(var.clone());
 
                         match self.sign_output.tree.get_leaf_ext(&path) {
+                            Some(Signature::Constant(expansion)) => {
+                                let ty = self.check_constant(expr_ty.clone(), expansion)?;
+                                self.unify(expr_ty, ty, loc)?
+                            }
                             Some(Signature::Builtin(builtin)) => {
                                 let ty = self.deanonymize(builtin.ty());
                                 self.unify(expr_ty, ty, loc)?
@@ -1609,6 +1639,33 @@ impl<'a> Context<'a> {
         self.types[param] = expr_ty;
 
         return Ok(expr_i);
+    }
+
+    /// Check an expression indepedently. Works with a fresh copies of `types`, `scopes`, and
+    /// `expr_order` to keep this typecheck independent from everything else.
+    fn check_expr_independent(&mut self, expr_ty: Ty, expression: &ast::Expression) -> CResult<Ty> {
+        let scopes = replace(&mut self.scopes, vec![]);
+        let expr_order = replace(&mut self.expr_order, vec![]);
+
+        let res = self.check_expr(expr_ty, expression)?;
+        let ty = self.expr_order[res].clone();
+
+        self.scopes = scopes;
+        self.expr_order = expr_order;
+
+        return Ok(ty);
+    }
+
+    /// Check a constant expansion.
+    fn check_constant(&mut self, expr_ty: Ty, expansion: &ast::Expression) -> CResult<Ty> {
+        let ty = self.check_expr_independent(expr_ty, expansion)?;
+        let ty = Ty::Transformed(ty.into(), Transformation::new(|mut expr| {
+            let name = expr.obj;
+            expr.obj = ExpressionObj::Rendered(quote! { #name !() });
+            Ok(Transformed::Expression(expr))
+        }));
+
+        return Ok(ty);
     }
 
     /// Check a (binary) operation that needs to unify to type `t`.
@@ -2169,6 +2226,10 @@ impl TryFrom<SignOutput> for CheckOutput {
                 for (_, def) in namespace.iter() {
                     match def {
                         Export::Item(Item::Defined(Located(_, def))) => match def {
+                            ast::TopLevelStatementObj::Constant { name, value } => {
+                                let output = Context::typecheck_constant(value, &sign_output, path)?;
+                                checked.insert(name.clone(), FinalContext::Constant(output));
+                            }
                             ast::TopLevelStatementObj::FunctionDef(func) => {
                                 let signature = sign_output
                                     .tree

--- a/src/core/compile/namespace/mod.rs
+++ b/src/core/compile/namespace/mod.rs
@@ -391,7 +391,8 @@ fn build_python_namespace(
                     }
                 }
             }
-            ca::TopLevelStatementObj::ClassDef { name, .. }
+            ca::TopLevelStatementObj::Constant { name, .. }
+            | ca::TopLevelStatementObj::ClassDef { name, .. }
             | ca::TopLevelStatementObj::FunctionDef(ca::FunctionDef { name, .. }) => {
                 let export = Export::Item(Item::Defined(Located(loc.clone(), obj.clone())));
                 namespace.insert(name.clone(), export);

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -1,7 +1,7 @@
 // TODO just throwing everything into mod.rs for now, don't want to deal with keeping things clean
 // yet
 use crate::core::{
-    clean::ast::{self as ca, ParamObj, Params},
+    clean::ast::{self as ca, ParamObj, Params, Expression},
     compile::{
         ast::ExpressionObj,
         build::{Transformation, Transformed},
@@ -13,7 +13,7 @@ use crate::core::{
 use crate::match1;
 // LOL I JUST LEARNED THAT I COULD DO THIS INSTEAD OF IMPORTING FROM CRATE
 use super::{
-    builtin::{Builtin, BuiltinSource},
+    builtin::{pyth::ExprContext, Builtin, BuiltinSource, Python},
     check::{DefinedType, ParamType, Ty, TyName},
 };
 use quote::quote;
@@ -93,6 +93,7 @@ pub type Signed = HashMap<String, Signature>;
 /// Signature of an object.
 #[derive(Clone, Debug)]
 pub enum Signature {
+    Constant(Expression),
     Class(ClassSignature),
     Function(FunctionSignature),
     Builtin(Builtin),
@@ -290,6 +291,9 @@ fn build_signature(
     let Located(loc, obj) = def;
 
     match obj {
+        ca::TopLevelStatementObj::Constant { value, .. } => {
+            Ok(Signature::Constant(value.clone()))
+        }
         ca::TopLevelStatementObj::ClassDef {
             body,
             bases,
@@ -480,7 +484,6 @@ fn build_signature(
         }
         ca::TopLevelStatementObj::FunctionDef(ca::FunctionDef {
             params,
-            // decorator_list,
             returns,
             ..
         }) => Ok(Signature::Function(build_function_signature(

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -1,7 +1,7 @@
 // TODO just throwing everything into mod.rs for now, don't want to deal with keeping things clean
 // yet
 use crate::core::{
-    clean::ast::{self as ca, ParamObj, Params, Expression},
+    clean::ast::{self as ca, Expression, ParamObj, Params},
     compile::{
         ast::ExpressionObj,
         build::{Transformation, Transformed},
@@ -291,9 +291,7 @@ fn build_signature(
     let Located(loc, obj) = def;
 
     match obj {
-        ca::TopLevelStatementObj::Constant { value, .. } => {
-            Ok(Signature::Constant(value.clone()))
-        }
+        ca::TopLevelStatementObj::Constant { value, .. } => Ok(Signature::Constant(value.clone())),
         ca::TopLevelStatementObj::ClassDef {
             body,
             bases,
@@ -483,9 +481,7 @@ fn build_signature(
             }
         }
         ca::TopLevelStatementObj::FunctionDef(ca::FunctionDef {
-            params,
-            returns,
-            ..
+            params, returns, ..
         }) => Ok(Signature::Function(build_function_signature(
             params, returns, abs, root,
         )?)),

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -62,7 +62,7 @@ impl ToTokens for Artifact {
             #![allow(unused_mut)]
 
             // Default imports
-            use crate::{id, assign, index_assign, seahorse_util::*, seahorse_const};
+            use crate::{id, seahorse_util::*};
             use std::{rc::Rc, cell::RefCell};
             use anchor_lang::{prelude::*, solana_program};
             // TODO might not need these, contexts are defined in lib.rs now
@@ -1312,16 +1312,6 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
             #[cfg(feature = "pyth-sdk-solana")]
             pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
 
-            #[macro_export]
-            macro_rules! seahorse_const {
-                ($name:ident, $value:expr) => {
-                    macro_rules! $name {
-                        () => { $value }
-                    }
-                    pub(crate) use $name;
-                }
-            }
-
             // A "Python mutable" object.
             pub struct Mutable<T>(Rc<RefCell<T>>);
 
@@ -1430,6 +1420,19 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
                 pub seeds: Option<Vec<Vec<u8>>>
             }
 
+            // This macro just expands to another macro, which is how constants are defined.
+            // The `pub(crate) use ...` lets us treat the macro exactly like any other crate-
+            // exported item.
+            #[macro_export]
+            macro_rules! seahorse_const {
+                ($name:ident, $value:expr) => {
+                    macro_rules! $name {
+                        () => { $value }
+                    }
+                    pub(crate) use $name;
+                }
+            }
+
             // Because of how `RefCell::borrow_mut()/borrow()` works, if we try to borrow from the
             // same value we're assigning to it will cause an error at runtime, for example:
             //
@@ -1476,6 +1479,10 @@ fn make_lib(origin: &Artifact, path: &Vec<String>, program_name: &String) -> CRe
                     $lval[temp_idx] = temp_rval;
                 }
             }
+
+            pub(crate) use seahorse_const;
+            pub(crate) use assign;
+            pub(crate) use index_assign;
         }
 
         #[program]

--- a/tests/compiled-examples/calculator.rs
+++ b/tests/compiled-examples/calculator.rs
@@ -7,7 +7,7 @@ pub mod program;
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unused_mut)]
-use crate::{assign, id, index_assign, seahorse_util::*};
+use crate::{id, seahorse_util::*};
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token::{self, Mint, Token, TokenAccount};
 use std::{cell::RefCell, rc::Rc};
@@ -263,6 +263,19 @@ pub mod seahorse_util {
     }
 
     #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    #[macro_export]
     macro_rules! assign {
         ($ lval : expr , $ rval : expr) => {{
             let temp = $rval;
@@ -280,6 +293,12 @@ pub mod seahorse_util {
             $lval[temp_idx] = temp_rval;
         };
     }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
 }
 
 #[program]

--- a/tests/compiled-examples/constants.rs
+++ b/tests/compiled-examples/constants.rs
@@ -1,0 +1,224 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{id, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+seahorse_const! { MAX , 7 }
+
+seahorse_const! { MESSAGE , "Hello constants" . to_string () }
+
+seahorse_const! { MIN , 2 }
+
+seahorse_const! { RANGE , (MAX ! () - MIN ! ()) }
+
+pub fn use_constants_handler<'info>(mut signer: SeahorseSigner<'info, '_>) -> () {
+    solana_program::msg!("{}", MESSAGE!());
+
+    for mut i in MIN!()..MAX!() {
+        solana_program::msg!("{} {}", "Step:".to_string(), i);
+    }
+
+    solana_program::msg!("{} {}", "Range:".to_string(), RANGE!());
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+pub mod seahorse_util {
+    use super::*;
+
+    #[cfg(feature = "pyth-sdk-solana")]
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    impl<T: Clone> Mutable<Vec<T>> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    impl<T: Clone, const N: usize> Mutable<[T; N]> {
+        pub fn wrapped_index(&self, mut index: i128) -> usize {
+            if index >= 0 {
+                return index.try_into().unwrap();
+            }
+
+            index += self.borrow().len() as i128;
+
+            return index.try_into().unwrap();
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
+}
+
+#[program]
+mod constants {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    pub struct UseConstants<'info> {
+        #[account(mut)]
+        pub signer: Signer<'info>,
+    }
+
+    pub fn use_constants(ctx: Context<UseConstants>) -> Result<()> {
+        let mut programs = HashMap::new();
+        let programs_map = ProgramsMap(programs);
+        let signer = SeahorseSigner {
+            account: &ctx.accounts.signer,
+            programs: &programs_map,
+        };
+
+        use_constants_handler(signer.clone());
+
+        return Ok(());
+    }
+}
+

--- a/tests/compiled-examples/event.rs
+++ b/tests/compiled-examples/event.rs
@@ -7,7 +7,7 @@ pub mod program;
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unused_mut)]
-use crate::{assign, id, index_assign, seahorse_util::*};
+use crate::{id, seahorse_util::*};
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token::{self, Mint, Token, TokenAccount};
 use std::{cell::RefCell, rc::Rc};
@@ -178,6 +178,19 @@ pub mod seahorse_util {
     }
 
     #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    #[macro_export]
     macro_rules! assign {
         ($ lval : expr , $ rval : expr) => {{
             let temp = $rval;
@@ -195,6 +208,12 @@ pub mod seahorse_util {
             $lval[temp_idx] = temp_rval;
         };
     }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
 }
 
 #[program]

--- a/tests/compiled-examples/fizzbuzz.rs
+++ b/tests/compiled-examples/fizzbuzz.rs
@@ -7,7 +7,7 @@ pub mod program;
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unused_mut)]
-use crate::{assign, id, index_assign, seahorse_util::*};
+use crate::{id, seahorse_util::*};
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token::{self, Mint, Token, TokenAccount};
 use std::{cell::RefCell, rc::Rc};
@@ -213,6 +213,19 @@ pub mod seahorse_util {
     }
 
     #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    #[macro_export]
     macro_rules! assign {
         ($ lval : expr , $ rval : expr) => {{
             let temp = $rval;
@@ -230,6 +243,12 @@ pub mod seahorse_util {
             $lval[temp_idx] = temp_rval;
         };
     }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
 }
 
 #[program]

--- a/tests/compiled-examples/hello.rs
+++ b/tests/compiled-examples/hello.rs
@@ -7,7 +7,7 @@ pub mod program;
 #![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unused_mut)]
-use crate::{assign, id, index_assign, seahorse_util::*};
+use crate::{id, seahorse_util::*};
 use anchor_lang::{prelude::*, solana_program};
 use anchor_spl::token::{self, Mint, Token, TokenAccount};
 use std::{cell::RefCell, rc::Rc};
@@ -217,6 +217,19 @@ pub mod seahorse_util {
     }
 
     #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    #[macro_export]
     macro_rules! assign {
         ($ lval : expr , $ rval : expr) => {{
             let temp = $rval;
@@ -234,6 +247,12 @@ pub mod seahorse_util {
             $lval[temp_idx] = temp_rval;
         };
     }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
 }
 
 #[program]


### PR DESCRIPTION
Finally taking on the oldest standing issue: constants.

We talked about the advantages/disadvantages of including typing in [Discord](https://discord.com/channels/1005658120548270224/1060703240188080200/1060708399525933197). Right this branch is dedicated to the "untyped constants" approach, which makes the Seahorse-facing UX a little smoother and more Python-native, at the expense of generated code readability.

Closes #2 