### PR TITLE
Import ordering bug

### DIFF
--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -1104,7 +1104,8 @@ impl TryFrom<CheckOutput> for BuildOutput {
 
                 for (name, export) in namespace.into_iter() {
                     match export {
-                        Export::Import(Located(_, ImportObj::SymbolPath(mut path) | ImportObj::ModulePath(mut path) | ImportObj::PackagePath(mut path))) => {
+                        NamespacedObject::Automatic(..) => {},
+                        NamespacedObject::Import(Located(_, ImportObj::SymbolPath(mut path) | ImportObj::ModulePath(mut path) | ImportObj::PackagePath(mut path))) => {
                             let mut node = match1!(artifact.uses.get_mut(0), Some(Use { tree: Tree::Node(node), .. }) => node);
                             let last = path.pop().unwrap();
 
@@ -1125,7 +1126,7 @@ impl TryFrom<CheckOutput> for BuildOutput {
 
                             node.insert(last, Tree::Leaf(None));
                         }
-                        Export::Item(item) => {
+                        NamespacedObject::Item(item) => {
                             match item {
                                 Item::Builtin(..) => {}
                                 Item::Defined(defined) => {

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -83,7 +83,7 @@ pub fn namespace() -> Namespace {
     for (name, obj) in data.into_iter() {
         namespace.insert(
             name.to_string(),
-            Export::Item(Item::Builtin(Builtin::Prelude(obj))),
+            NamespacedObject::Automatic(Builtin::Prelude(obj)),
         );
     }
 

--- a/src/core/compile/builtin/pyth.rs
+++ b/src/core/compile/builtin/pyth.rs
@@ -35,7 +35,7 @@ pub fn namespace() -> Namespace {
     for (name, obj) in data.into_iter() {
         namespace.insert(
             name.to_string(),
-            Export::Item(Item::Builtin(Builtin::Pyth(obj))),
+            NamespacedObject::Item(Item::Builtin(Builtin::Pyth(obj))),
         );
     }
 

--- a/src/core/compile/builtin/python.rs
+++ b/src/core/compile/builtin/python.rs
@@ -4,6 +4,8 @@ use crate::{
     core::compile::{ast::*, build::*, builtin::*},
     match1,
 };
+use std::collections::BTreeMap;
+use prelude::{NamespacedObject, Namespace};
 use quote::quote;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -33,6 +35,42 @@ pub enum Python {
     Sorted,
     Sum,
     ListConstructor,
+}
+
+/// Create the Python builtins namespace.
+pub fn namespace() -> Namespace {
+    let data = [
+        ("None", Python::None),
+        ("List", Python::List),
+        ("Tuple", Python::Tuple),
+        ("int", Python::Int),
+        ("bool", Python::Bool),
+        ("str", Python::Str),
+        ("abs", Python::Abs),
+        ("print", Python::Print),
+        ("min", Python::Min),
+        ("max", Python::Max),
+        ("round", Python::Round),
+        ("range", Python::Range),
+        ("len", Python::Len),
+        ("enumerate", Python::Enumerate),
+        ("filter", Python::Filter),
+        ("map", Python::Map),
+        ("zip", Python::Zip),
+        ("sorted", Python::Sorted),
+        ("sum", Python::Sum),
+        ("list", Python::ListConstructor),
+    ];
+
+    let mut namespace = BTreeMap::new();
+    for (name, obj) in data.into_iter() {
+        namespace.insert(
+            name.to_string(),
+            NamespacedObject::Automatic(Builtin::Python(obj)),
+        );
+    }
+
+    return namespace;
 }
 
 impl Python {

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -218,11 +218,11 @@ impl TryFrom<NamespaceOutput> for SignOutput {
 
                 for (name, export) in namespace.iter() {
                     match export {
-                        Export::Item(Item::Defined(def)) => {
+                        NamespacedObject::Item(Item::Defined(def)) => {
                             let signature = build_signature(def, abs, &namespace_output.tree)?;
                             signatures.insert(name.clone(), signature);
                         }
-                        Export::Item(Item::Builtin(builtin)) => {
+                        NamespacedObject::Automatic(builtin) | NamespacedObject::Item(Item::Builtin(builtin)) => {
                             signatures.insert(builtin.name(), Signature::Builtin(builtin.clone()));
                         }
                         _ => {}

--- a/src/core/util.rs
+++ b/src/core/util.rs
@@ -1,6 +1,6 @@
 use owo_colors::OwoColorize;
 use rustpython_parser::ast::Location as SrcLocation;
-use std::{collections::HashMap, error, fmt, rc::Rc};
+use std::{collections::{HashMap, BTreeMap}, error, fmt, rc::Rc};
 
 /// Match and extract against a single pattern, panicking if no match.
 #[macro_export]
@@ -419,6 +419,16 @@ impl<T> Tree<Option<T>> {
 }
 
 impl<T> Tree<HashMap<String, T>> {
+    /// Get the "leaf of a leaf" from a tree.
+    pub fn get_leaf_ext<'a>(&'a self, path: &Vec<String>) -> Option<&'a T> {
+        let mut path = path.clone();
+        let name = path.pop()?;
+
+        return self.get_leaf(&path).and_then(|leaf| leaf.get(&name));
+    }
+}
+
+impl<T> Tree<BTreeMap<String, T>> {
     /// Get the "leaf of a leaf" from a tree.
     pub fn get_leaf_ext<'a>(&'a self, path: &Vec<String>) -> Option<&'a T> {
         let mut path = path.clone();


### PR DESCRIPTION
[See thread in Discord.](https://discord.com/channels/1005658120548270224/1006027721127776388/1044354381816025160)

The general problem is that Seahorse-builtin objects like everything in `seahorse.prelude` are treated like normal imports. If you have a module that does `from seahorse.prelude import *`, then you import everything in that module from another module (`from my_module import *`), then it will carry the prelude names with it. This could cause a bug at compile time, since the compiler didn't know how to handle builtin objects that come from a different module.

We discussed the best solutions in Discord and decided that `prelude` could just be imported automatically but not exported (like Python builtins), and then still allow other builtins to be re-exported. So there's essentially three cases for imports:
- Automatic builtin imports - `seahorse.prelude` (`u64, Account, etc.`) and Python builtins (`str, min, max, etc.`)
- Manual builtin imports like `seahorse.pyth`
- Code imports that the user has written

Closes #57