### PR TITLE
Fix Pyth `get_price` and add `Price.publish_time` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Access to Pyth `Price.publish_time` (#91)
+
+### Fixed
+
+- Pyth compile error on latest version (#91)
+
 ## [0.2.7]
 
 ### Added

--- a/data/const/seahorse_pyth.py
+++ b/data/const/seahorse_pyth.py
@@ -14,12 +14,13 @@ class Price:
     """
     Pyth `Price` struct with some extra convenience functions. You can access the raw data of the struct through its fields.
 
-    "A price with a degree of uncertainty, represented as a price +- a confidence interval." (from https://docs.rs/pyth-sdk-solana/0.7.0/pyth_sdk_solana/struct.Price.html)
+    "A price with a degree of uncertainty, represented as a price +- a confidence interval." (from https://docs.rs/pyth-sdk-solana/0.7.1/pyth_sdk_solana/struct.Price.html)
     """
 
     price: i64
     conf: u64
     expo: i32
+    publish_time: i64
 
     def num(self) -> f64:
         """Simply get price as a floating-point number. Does not take confidence into account, instead reporting the average estimated price."""
@@ -29,7 +30,7 @@ class PriceFeed:
     """
     Pyth `PriceFeed` struct with some extra convience functions.
 
-    "Represents a current aggregation price from pyth publisher feeds." (from https://docs.rs/pyth-sdk-solana/0.7.0/pyth_sdk_solana/struct.PriceFeed.html)
+    "Represents a current aggregation price from pyth publisher feeds." (from https://docs.rs/pyth-sdk-solana/0.7.1/pyth_sdk_solana/struct.PriceFeed.html)
     """
 
     def get_price(self) -> Price:

--- a/src/bin/cli/init.rs
+++ b/src/bin/cli/init.rs
@@ -209,7 +209,7 @@ pub fn init(args: InitArgs) -> Result<(), Box<dyn Error>> {
             let mut pyth = InlineTable::new();
             pyth.insert(
                 "version",
-                Value::String(Formatted::new("0.7.0".to_string())),
+                Value::String(Formatted::new("0.7.1".to_string())),
             );
             pyth.insert("optional", Value::Boolean(Formatted::new(true)));
             cargo["dependencies"]["pyth-sdk-solana"] = Item::Value(Value::InlineTable(pyth));

--- a/src/core/compile/builtin/pyth.rs
+++ b/src/core/compile/builtin/pyth.rs
@@ -166,7 +166,7 @@ impl BuiltinSource for Pyth {
                             let price = match1!(function.obj, ExpressionObj::Attribute { value, .. } => *value);
 
                             expr.obj = ExpressionObj::Rendered(quote! {
-                                #price.get_current_price().unwrap()
+                                #price.get_price_unchecked()
                             });
 
                             Ok(Transformed::Expression(expr))
@@ -188,6 +188,11 @@ impl BuiltinSource for Pyth {
             (Self::Price, "expo") => Some((
                 ty_no_params,
                 Ty::prelude(Prelude::RustInt(true, 32), vec![]),
+            )),
+            // Price.publish_time: i64
+            (Self::Price, "publish_time") => Some((
+                ty_no_params,
+                Ty::prelude(Prelude::RustInt(true, 64), vec![]),
             )),
             // Price.num() -> f64
             (Self::Price, "num") => Some((


### PR DESCRIPTION
`get_price` method was removed in the latest `pyth-sdk-solana` crate which results in compilation error. This PR updates to call the [new](https://docs.rs/pyth-sdk-solana/0.7.1/pyth_sdk_solana/struct.PriceFeed.html#method.get_price_unchecked) method.

There is also a new property in `Price` struct called `publish_time` and it is now accesible from Seahorse too.