### PR TITLE
Getting loads/stores to work with all mutable types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Access to Pyth `Price.publish_time` (#91)
+- Accounts can now store complex types (lists, user-defined classes, multi-dimensional arrays, etc.)
 
 ### Fixed
 
 - Bug with unary not operator
 - Pyth compile error on latest version (#91)
+- Bug that prevented lists from being used in events
+- Bug that prevented users from importing accounts from other files
 
 ## [0.2.7]
 

--- a/examples/stored_mutables.py
+++ b/examples/stored_mutables.py
@@ -1,0 +1,81 @@
+from seahorse.prelude import *
+from util.more_data import MoreData
+
+
+declare_id('Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS')
+
+
+class MyEvent(Event):
+    nums: List[i32]
+
+
+class Deep:
+    num: i32
+
+    def __init__(self, num: i32):
+        self.num = num
+
+
+class Nested:
+    deep: Deep
+
+    def __init__(self, num: i32):
+        self.deep = Deep(num)
+    
+    def reset(self):
+        self.deep = Deep(0)
+
+
+class Flag(Enum):
+    OFF = 1
+    ON = 2
+
+
+class Data(Account):
+    array_2d: Array[Array[i32, 2], 2]
+    int_list: List[i32]
+    int_list_2d: List[List[i32]]
+    string: str
+    nested: Nested
+    nested_list: List[Nested]
+    flag: Flag
+    more_data: MoreData
+
+
+@instruction
+def init(signer: Signer, data: Empty[Data]):
+    init_data = data.init(
+        payer=signer,
+        seeds=[signer],
+        padding=1024
+    )
+
+    init_data.int_list = [1, 2]
+    init_data.int_list_2d = [[3, 4], [5, 6]]
+    init_data.string = 'Hello'
+    init_data.nested = Nested(7)
+    init_data.nested_list = [Nested(8), Nested(9)]
+    init_data.more_data = MoreData(10)
+
+
+@instruction
+def test_stored_mutables(signer: Signer, data: Data):
+    # Modify everything in the Data account 
+
+    # [[0, 0], [0, 0]] -> [[1, 0], [0, 0]]
+    data.array_2d[0][0] = 1
+    # [1, 2] -> [1, 2, 0]
+    data.int_list.append(0)
+    # [[3, 4], [5, 6]] -> [[3, 0], [5, 6]]
+    data.int_list_2d[0][-1] = 0
+    # "Hello" -> "Hello World"
+    data.string = data.string + ' World'
+    # N(D(7)) -> N(D(0))
+    data.nested.reset()
+    # [N(D(8)), N(D(9))] -> [N(D(0)), N(D(9)), N(D(10))]
+    data.nested_list[0].reset()
+    data.nested_list.append(Nested(10))
+    # OFF -> ON
+    data.flag = Flag.ON
+    # MD(10) -> MD(11)
+    data.more_data = MoreData(11)

--- a/examples/util/more_data.py
+++ b/examples/util/more_data.py
@@ -1,0 +1,8 @@
+from seahorse.prelude import *
+
+
+class MoreData:
+    num: i32
+
+    def __init__(self, num: i32):
+        self.num = num

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -420,19 +420,6 @@ impl ExpressionObj {
         }
     }
 
-    /// Return whether this expression is the last in a chain of borrowable
-    /// expressions. Only attributes (fields, not method functions) and index
-    /// operations (regular, not tuple indexing) may get turned into borrows.
-    /// 
-    /// This method is needed because when adding borrows to an expression tree
-    /// in the context of an lval, we need to make sure that only one BorrowMut
-    /// is added.
-    // pub fn is_last_borrowable(&self) -> bool {
-    //     match self {
-    //         Self::Attribute { value } if !value.ty.is
-    //     }
-    // }
-
     pub fn without_borrows(self) -> Self {
         match self {
             Self::BinOp { left, op, right } => Self::BinOp {

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -89,13 +89,14 @@ pub enum TyExpr {
         mutability: Mutability,
         name: Vec<String>,
         params: Vec<TyExpr>,
+        is_loadable: bool,
     },
     Array {
         element: Box<TyExpr>,
         size: Box<TyExpr>,
     },
     Tuple(Vec<TyExpr>),
-    Account(Vec<String>),
+    Account(Vec<String>), // Type expression explicitly for defined accounts
     Const(usize),
     InfoLifetime,
     AnonLifetime,
@@ -114,6 +115,7 @@ impl TyExpr {
             mutability,
             name: name.into_iter().map(|part| part.to_string()).collect(),
             params: vec![],
+            is_loadable: false,
         }
     }
 

--- a/src/core/compile/ast.rs
+++ b/src/core/compile/ast.rs
@@ -236,11 +236,6 @@ pub enum Statement {
         receiver: TypedExpression,
         value: TypedExpression,
     },
-    IndexAssign {
-        receiver: TypedExpression,
-        index: TypedExpression,
-        value: TypedExpression,
-    },
     Expression(TypedExpression),
     Return(Option<TypedExpression>),
     Break,
@@ -424,6 +419,19 @@ impl ExpressionObj {
             _ => false,
         }
     }
+
+    /// Return whether this expression is the last in a chain of borrowable
+    /// expressions. Only attributes (fields, not method functions) and index
+    /// operations (regular, not tuple indexing) may get turned into borrows.
+    /// 
+    /// This method is needed because when adding borrows to an expression tree
+    /// in the context of an lval, we need to make sure that only one BorrowMut
+    /// is added.
+    // pub fn is_last_borrowable(&self) -> bool {
+    //     match self {
+    //         Self::Attribute { value } if !value.ty.is
+    //     }
+    // }
 
     pub fn without_borrows(self) -> Self {
         match self {

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -487,21 +487,9 @@ impl Context {
                             self.build_expression(target, vec![ExprContext::LVal].into())?;
                         let rval = self.build_expression(value, vec![].into())?;
 
-                        if let TypedExpression {
-                            obj: ExpressionObj::Index { value, index },
-                            ..
-                        } = receiver
-                        {
-                            Statement::IndexAssign {
-                                receiver: *value,
-                                index: *index,
-                                value: rval,
-                            }
-                        } else {
-                            Statement::Assign {
-                                receiver,
-                                value: rval,
-                            }
+                        Statement::Assign {
+                            receiver,
+                            value: rval,
                         }
                     }
                     Assign::Declare { undeclared, target } => Statement::Let {

--- a/src/core/compile/build/mod.rs
+++ b/src/core/compile/build/mod.rs
@@ -222,24 +222,28 @@ fn make_ty_expr(ty_expr: ast::TyExpression, ty: Ty) -> TyExpr {
                         mutability,
                         name: vec!["Vec".to_string()],
                         params,
+                        is_loadable: false
                     },
                     // str -> String
                     Builtin::Python(Python::Str) => TyExpr::Generic {
                         mutability,
                         name: vec!["String".to_string()],
                         params,
+                        is_loadable: false
                     },
                     // Empty[T] -> Empty<T>
                     Builtin::Prelude(Prelude::Empty) => TyExpr::Generic {
                         mutability: Mutability::Immutable,
                         name: vec!["Empty".to_string()],
                         params,
+                        is_loadable: false
                     },
                     // Signer -> SeahorseSigner<'entrypoint, 'info>
                     Builtin::Prelude(Prelude::Signer) => TyExpr::Generic {
                         mutability: Mutability::Immutable,
                         name: vec!["SeahorseSigner".to_string()],
                         params: vec![TyExpr::InfoLifetime, TyExpr::AnonLifetime],
+                        is_loadable: false
                     },
                     // TokenMint -> SeahorseAccount<'entrypoint, 'info, Mint>>
                     Builtin::Prelude(Prelude::TokenMint) => TyExpr::Generic {
@@ -250,6 +254,7 @@ fn make_ty_expr(ty_expr: ast::TyExpression, ty: Ty) -> TyExpr {
                             TyExpr::AnonLifetime,
                             TyExpr::new_specific(vec!["Mint"], Mutability::Immutable),
                         ],
+                        is_loadable: false
                     },
                     // TokenAccount -> SeahorseAccount<'entrypoint, 'info, TokenAccount>>
                     Builtin::Prelude(Prelude::TokenAccount) => TyExpr::Generic {
@@ -260,6 +265,7 @@ fn make_ty_expr(ty_expr: ast::TyExpression, ty: Ty) -> TyExpr {
                             TyExpr::AnonLifetime,
                             TyExpr::new_specific(vec!["TokenAccount"], Mutability::Immutable),
                         ],
+                        is_loadable: false
                     },
                     // Program, UncheckedAccount, pyth.PriceAccount -> UncheckedAccount<'info>
                     Builtin::Prelude(Prelude::Program | Prelude::UncheckedAccount)
@@ -267,6 +273,7 @@ fn make_ty_expr(ty_expr: ast::TyExpression, ty: Ty) -> TyExpr {
                         mutability: Mutability::Immutable,
                         name: vec!["UncheckedAccount".to_string()],
                         params: vec![TyExpr::InfoLifetime],
+                        is_loadable: false
                     },
                     // Clock -> Sysvar<'info, Clock>
                     Builtin::Prelude(Prelude::Clock) => TyExpr::Generic {
@@ -276,21 +283,33 @@ fn make_ty_expr(ty_expr: ast::TyExpression, ty: Ty) -> TyExpr {
                             TyExpr::InfoLifetime,
                             TyExpr::new_specific(vec!["Clock"], Mutability::Immutable),
                         ],
+                        is_loadable: false
                     },
                     // Everything else
                     builtin => TyExpr::Generic {
                         mutability,
                         name: vec![builtin.name()],
                         params,
+                        is_loadable: false
                     },
                 },
                 TyName::Defined(
                     _,
-                    DefinedType::Struct | DefinedType::Enum | DefinedType::Event,
+                    DefinedType::Struct,
                 ) => TyExpr::Generic {
                     mutability,
                     name: base,
                     params,
+                    is_loadable: true
+                },
+                TyName::Defined(
+                    _,
+                    DefinedType::Enum | DefinedType::Event,
+                ) => TyExpr::Generic {
+                    mutability,
+                    name: base,
+                    params,
+                    is_loadable: false
                 },
                 TyName::Defined(_, DefinedType::Account) => TyExpr::Account(base),
             }

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -1192,21 +1192,17 @@ impl BuiltinSource for Prelude {
                     Ty::Transformed(
                         Ty::Anonymous(0).into(),
                         Transformation::new(|mut expr| {
-                            let (value, mut index) = match1!(expr.obj, ExpressionObj::Index { value, index } => (*value, *index));
-                            let value_unwrapped = match &value.obj {
-                                ExpressionObj::BorrowImmut(value) => &**value,
-                                ExpressionObj::BorrowMut(value) => &**value,
-                                _ => panic!(),
-                            };
-
-                            index.obj = ExpressionObj::Rendered(quote! {
-                                #value_unwrapped.wrapped_index(#index as i128)
-                            });
-
-                            expr.obj = ExpressionObj::Index {
-                                value: value.into(),
-                                index: index.into(),
-                            };
+                            let (value, index) = match1!(expr.obj, ExpressionObj::Index { value, index } => (*value, *index));
+                            
+                            if let ExpressionObj::BorrowMut(..) = &value.obj {
+                                expr.obj = ExpressionObj::Rendered(quote! {
+                                    (*#value.index_wrapped_mut(#index.into()))
+                                });
+                            } else {
+                                expr.obj = ExpressionObj::Rendered(quote! {
+                                    (*#value.index_wrapped(#index.into()))
+                                });
+                            }
 
                             Ok(Transformed::Expression(expr))
                         }),

--- a/src/core/compile/builtin/prelude.rs
+++ b/src/core/compile/builtin/prelude.rs
@@ -1,6 +1,6 @@
 //! The Seahorse Prelude includes a bunch of builtin types that convert to Rust/Anchor.
 
-use crate::core::compile::builtin::*;
+use crate::core::{compile::builtin::*, generate::LoadedTyExpr};
 pub use crate::core::{
     compile::{ast::*, build::*, check::*, namespace::*, sign::*},
     util::*,
@@ -140,10 +140,12 @@ impl BuiltinSource for Prelude {
                                     mutability: Mutability::Immutable,
                                     name: vec![format!("{}", Ty::prelude(self.clone(), vec![]))],
                                     params: vec![],
+                                    is_loadable: false
                                 };
 
                                 Transformation::new(move |mut expr| {
                                     let x = match1!(expr.obj, ExpressionObj::Call { args, .. } => args.into_iter().next().unwrap());
+                                    let ty = LoadedTyExpr(&ty);
 
                                     expr.obj = ExpressionObj::Rendered(quote! {
                                         <#ty as TryFrom<_>>::try_from(#x).unwrap()
@@ -1285,6 +1287,7 @@ impl BuiltinSource for Prelude {
                                     mutability: Mutability::Immutable,
                                     name: vec![format!("{}", expr.ty)],
                                     params: vec![],
+                                    is_loadable: false
                                 },
                                 value: expr.obj.into(),
                             };
@@ -1302,6 +1305,7 @@ impl BuiltinSource for Prelude {
                                     mutability: Mutability::Immutable,
                                     name: vec![format!("{}", expr.ty)],
                                     params: vec![],
+                                    is_loadable: false
                                 },
                                 value: expr.obj.into(),
                             };

--- a/src/core/compile/sign/mod.rs
+++ b/src/core/compile/sign/mod.rs
@@ -138,8 +138,9 @@ impl StructSignature {
                         Transformation::new(|mut expr| {
                             let (class, args) = match1!(expr.obj, ExpressionObj::Call { function, args } => (function, args));
 
+                            // The __new__ function is defined on the loaded type
                             expr.obj = ExpressionObj::Rendered(quote! {
-                                #class::__new__(#(#args),*)
+                                <Loaded!(#class)>::__new__(#(#args),*)
                             });
 
                             Ok(Transformed::Expression(expr))

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -207,6 +207,15 @@ fn stored_field(expr: TokenStream, ty: &TyExpr) -> TokenStream {
                 #expr.borrow().clone().into_iter().map(|element| #inner).collect()
             }
         }
+        // TODO hack to get strings working with accounts
+        // Not sure if the assumption made in this function should be "expr is assumed to be owned"
+        // or "expr is assumed to be borrowed," since cloning to assert ownership is safer but might
+        // be needlessly expensive
+        TyExpr::Generic { name, .. } if name == &["String"] => {
+            quote! {
+                #expr.clone()
+            }
+        }
         TyExpr::Generic { is_loadable, mutability, .. } => {
             let inner = match mutability {
                 Mutability::Immutable => expr,

--- a/src/core/generate/mod.rs
+++ b/src/core/generate/mod.rs
@@ -646,8 +646,8 @@ impl<'a> ToTokens for StoredTyExpr<'a> {
                 quote! { #path #params }
             }
             TyExpr::Array { element, size } => {
-                let element = LoadedTyExpr(element.as_ref());
-                let size = LoadedTyExpr(size.as_ref());
+                let element = StoredTyExpr(element.as_ref());
+                let size = StoredTyExpr(size.as_ref());
 
                 quote! { [#element; #size] }
             },

--- a/tests/compiled-examples/calculator.rs
+++ b/tests/compiled-examples/calculator.rs
@@ -159,7 +159,11 @@ pub mod seahorse_util {
 
     #[cfg(feature = "pyth-sdk-solana")]
     pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
-    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Deref, Index, IndexMut},
+    };
 
     pub struct Mutable<T>(Rc<RefCell<T>>);
 
@@ -195,27 +199,65 @@ pub mod seahorse_util {
         }
     }
 
-    impl<T: Clone> Mutable<Vec<T>> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    pub trait IndexWrapped {
+        type Output;
+
+        fn index_wrapped(&self, index: i128) -> &Self::Output;
+    }
+
+    pub trait IndexWrappedMut: IndexWrapped {
+        fn index_wrapped_mut(&mut self, index: i128) -> &mut <Self as IndexWrapped>::Output;
+    }
+
+    impl<T> IndexWrapped for Vec<T> {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index(index)
         }
     }
 
-    impl<T: Clone, const N: usize> Mutable<[T; N]> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    impl<T> IndexWrappedMut for Vec<T> {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index_mut(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrapped for [T; N] {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrappedMut for [T; N] {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
         }
     }
 
@@ -274,6 +316,22 @@ pub mod seahorse_util {
             pub(crate) use $name;
         };
     }
+
+    pub trait Loadable {
+        type Loaded;
+
+        fn load(stored: Self) -> Self::Loaded;
+
+        fn store(loaded: Self::Loaded) -> Self;
+    }
+
+    macro_rules! Loaded {
+        ($ name : ty) => {
+            <$name as Loadable>::Loaded
+        };
+    }
+
+    pub(crate) use Loaded;
 
     #[macro_export]
     macro_rules! assign {

--- a/tests/compiled-examples/constants.rs
+++ b/tests/compiled-examples/constants.rs
@@ -54,7 +54,11 @@ pub mod seahorse_util {
 
     #[cfg(feature = "pyth-sdk-solana")]
     pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
-    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Deref, Index, IndexMut},
+    };
 
     pub struct Mutable<T>(Rc<RefCell<T>>);
 
@@ -90,27 +94,65 @@ pub mod seahorse_util {
         }
     }
 
-    impl<T: Clone> Mutable<Vec<T>> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    pub trait IndexWrapped {
+        type Output;
+
+        fn index_wrapped(&self, index: i128) -> &Self::Output;
+    }
+
+    pub trait IndexWrappedMut: IndexWrapped {
+        fn index_wrapped_mut(&mut self, index: i128) -> &mut <Self as IndexWrapped>::Output;
+    }
+
+    impl<T> IndexWrapped for Vec<T> {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index(index)
         }
     }
 
-    impl<T: Clone, const N: usize> Mutable<[T; N]> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    impl<T> IndexWrappedMut for Vec<T> {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index_mut(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrapped for [T; N] {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrappedMut for [T; N] {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
         }
     }
 
@@ -169,6 +211,22 @@ pub mod seahorse_util {
             pub(crate) use $name;
         };
     }
+
+    pub trait Loadable {
+        type Loaded;
+
+        fn load(stored: Self) -> Self::Loaded;
+
+        fn store(loaded: Self::Loaded) -> Self;
+    }
+
+    macro_rules! Loaded {
+        ($ name : ty) => {
+            <$name as Loadable>::Loaded
+        };
+    }
+
+    pub(crate) use Loaded;
 
     #[macro_export]
     macro_rules! assign {

--- a/tests/compiled-examples/fizzbuzz.rs
+++ b/tests/compiled-examples/fizzbuzz.rs
@@ -109,7 +109,11 @@ pub mod seahorse_util {
 
     #[cfg(feature = "pyth-sdk-solana")]
     pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
-    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Deref, Index, IndexMut},
+    };
 
     pub struct Mutable<T>(Rc<RefCell<T>>);
 
@@ -145,27 +149,65 @@ pub mod seahorse_util {
         }
     }
 
-    impl<T: Clone> Mutable<Vec<T>> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    pub trait IndexWrapped {
+        type Output;
+
+        fn index_wrapped(&self, index: i128) -> &Self::Output;
+    }
+
+    pub trait IndexWrappedMut: IndexWrapped {
+        fn index_wrapped_mut(&mut self, index: i128) -> &mut <Self as IndexWrapped>::Output;
+    }
+
+    impl<T> IndexWrapped for Vec<T> {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index(index)
         }
     }
 
-    impl<T: Clone, const N: usize> Mutable<[T; N]> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    impl<T> IndexWrappedMut for Vec<T> {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index_mut(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrapped for [T; N] {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrappedMut for [T; N] {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
         }
     }
 
@@ -224,6 +266,22 @@ pub mod seahorse_util {
             pub(crate) use $name;
         };
     }
+
+    pub trait Loadable {
+        type Loaded;
+
+        fn load(stored: Self) -> Self::Loaded;
+
+        fn store(loaded: Self::Loaded) -> Self;
+    }
+
+    macro_rules! Loaded {
+        ($ name : ty) => {
+            <$name as Loadable>::Loaded
+        };
+    }
+
+    pub(crate) use Loaded;
 
     #[macro_export]
     macro_rules! assign {

--- a/tests/compiled-examples/hello.rs
+++ b/tests/compiled-examples/hello.rs
@@ -113,7 +113,11 @@ pub mod seahorse_util {
 
     #[cfg(feature = "pyth-sdk-solana")]
     pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
-    use std::{collections::HashMap, fmt::Debug, ops::Deref};
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Deref, Index, IndexMut},
+    };
 
     pub struct Mutable<T>(Rc<RefCell<T>>);
 
@@ -149,27 +153,65 @@ pub mod seahorse_util {
         }
     }
 
-    impl<T: Clone> Mutable<Vec<T>> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    pub trait IndexWrapped {
+        type Output;
+
+        fn index_wrapped(&self, index: i128) -> &Self::Output;
+    }
+
+    pub trait IndexWrappedMut: IndexWrapped {
+        fn index_wrapped_mut(&mut self, index: i128) -> &mut <Self as IndexWrapped>::Output;
+    }
+
+    impl<T> IndexWrapped for Vec<T> {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index(index)
         }
     }
 
-    impl<T: Clone, const N: usize> Mutable<[T; N]> {
-        pub fn wrapped_index(&self, mut index: i128) -> usize {
-            if index >= 0 {
-                return index.try_into().unwrap();
+    impl<T> IndexWrappedMut for Vec<T> {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += self.len() as i128;
             }
 
-            index += self.borrow().len() as i128;
+            let index: usize = index.try_into().unwrap();
 
-            return index.try_into().unwrap();
+            self.index_mut(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrapped for [T; N] {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrappedMut for [T; N] {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
         }
     }
 
@@ -228,6 +270,22 @@ pub mod seahorse_util {
             pub(crate) use $name;
         };
     }
+
+    pub trait Loadable {
+        type Loaded;
+
+        fn load(stored: Self) -> Self::Loaded;
+
+        fn store(loaded: Self::Loaded) -> Self;
+    }
+
+    macro_rules! Loaded {
+        ($ name : ty) => {
+            <$name as Loadable>::Loaded
+        };
+    }
+
+    pub(crate) use Loaded;
 
     #[macro_export]
     macro_rules! assign {

--- a/tests/compiled-examples/stored_mutables.rs
+++ b/tests/compiled-examples/stored_mutables.rs
@@ -1,0 +1,745 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+pub mod util;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::dot::util::more_data::MoreData;
+use crate::{id, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+#[account]
+#[derive(Debug)]
+pub struct Data {
+    pub array_2d: [[i32; 2]; 2],
+    pub int_list: Vec<i32>,
+    pub int_list_2d: Vec<Vec<i32>>,
+    pub string: String,
+    pub nested: Nested,
+    pub nested_list: Vec<Nested>,
+    pub flag: Flag,
+    pub more_data: MoreData,
+}
+
+impl<'info, 'entrypoint> Data {
+    pub fn load(
+        account: &'entrypoint mut Box<Account<'info, Self>>,
+        programs_map: &'entrypoint ProgramsMap<'info>,
+    ) -> Mutable<LoadedData<'info, 'entrypoint>> {
+        let array_2d = Mutable::new(
+            account
+                .array_2d
+                .clone()
+                .map(|element| Mutable::new(element.map(|element| element))),
+        );
+
+        let int_list = Mutable::new(
+            account
+                .int_list
+                .clone()
+                .into_iter()
+                .map(|element| element)
+                .collect(),
+        );
+
+        let int_list_2d = Mutable::new(
+            account
+                .int_list_2d
+                .clone()
+                .into_iter()
+                .map(|element| Mutable::new(element.into_iter().map(|element| element).collect()))
+                .collect(),
+        );
+
+        let string = account.string.clone();
+        let nested = Mutable::new(Nested::load(account.nested.clone()));
+        let nested_list = Mutable::new(
+            account
+                .nested_list
+                .clone()
+                .into_iter()
+                .map(|element| Mutable::new(Nested::load(element)))
+                .collect(),
+        );
+
+        let flag = account.flag.clone();
+        let more_data = Mutable::new(MoreData::load(account.more_data.clone()));
+
+        Mutable::new(LoadedData {
+            __account__: account,
+            __programs__: programs_map,
+            array_2d,
+            int_list,
+            int_list_2d,
+            string,
+            nested,
+            nested_list,
+            flag,
+            more_data,
+        })
+    }
+
+    pub fn store(loaded: Mutable<LoadedData>) {
+        let mut loaded = loaded.borrow_mut();
+        let array_2d = loaded
+            .array_2d
+            .clone()
+            .borrow()
+            .clone()
+            .map(|element| element.borrow().clone().map(|element| element));
+
+        loaded.__account__.array_2d = array_2d;
+
+        let int_list = loaded
+            .int_list
+            .clone()
+            .borrow()
+            .clone()
+            .into_iter()
+            .map(|element| element)
+            .collect();
+
+        loaded.__account__.int_list = int_list;
+
+        let int_list_2d = loaded
+            .int_list_2d
+            .clone()
+            .borrow()
+            .clone()
+            .into_iter()
+            .map(|element| {
+                element
+                    .borrow()
+                    .clone()
+                    .into_iter()
+                    .map(|element| element)
+                    .collect()
+            })
+            .collect();
+
+        loaded.__account__.int_list_2d = int_list_2d;
+
+        let string = loaded.string.clone();
+
+        loaded.__account__.string = string;
+
+        let nested = Nested::store(loaded.nested.clone().borrow().clone());
+
+        loaded.__account__.nested = nested;
+
+        let nested_list = loaded
+            .nested_list
+            .clone()
+            .borrow()
+            .clone()
+            .into_iter()
+            .map(|element| Nested::store(element.borrow().clone()))
+            .collect();
+
+        loaded.__account__.nested_list = nested_list;
+
+        let flag = loaded.flag.clone();
+
+        loaded.__account__.flag = flag;
+
+        let more_data = MoreData::store(loaded.more_data.clone().borrow().clone());
+
+        loaded.__account__.more_data = more_data;
+    }
+}
+
+#[derive(Debug)]
+pub struct LoadedData<'info, 'entrypoint> {
+    pub __account__: &'entrypoint mut Box<Account<'info, Data>>,
+    pub __programs__: &'entrypoint ProgramsMap<'info>,
+    pub array_2d: Mutable<[Mutable<[i32; 2]>; 2]>,
+    pub int_list: Mutable<Vec<i32>>,
+    pub int_list_2d: Mutable<Vec<Mutable<Vec<i32>>>>,
+    pub string: String,
+    pub nested: Mutable<Loaded!(Nested)>,
+    pub nested_list: Mutable<Vec<Mutable<Loaded!(Nested)>>>,
+    pub flag: Flag,
+    pub more_data: Mutable<Loaded!(MoreData)>,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct Deep {
+    pub num: i32,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoadedDeep {
+    pub num: i32,
+}
+
+impl Mutable<LoadedDeep> {
+    pub fn __init__(&self, mut num: i32) -> () {
+        assign!(self.borrow_mut().num, num);
+    }
+}
+
+impl LoadedDeep {
+    pub fn __new__(num: i32) -> Mutable<Self> {
+        let obj = Mutable::new(LoadedDeep::default());
+
+        obj.__init__(num);
+
+        return obj;
+    }
+}
+
+impl Loadable for Deep {
+    type Loaded = LoadedDeep;
+
+    fn load(stored: Self) -> Self::Loaded {
+        Self::Loaded { num: stored.num }
+    }
+
+    fn store(loaded: Self::Loaded) -> Self {
+        Self { num: loaded.num }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, AnchorSerialize, AnchorDeserialize, Copy)]
+pub enum Flag {
+    OFF,
+    ON,
+}
+
+impl Default for Flag {
+    fn default() -> Self {
+        Flag::OFF
+    }
+}
+
+#[event]
+pub struct MyEvent {
+    pub nums: Vec<i32>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoadedMyEvent {
+    pub nums: Mutable<Vec<i32>>,
+}
+
+impl Mutable<LoadedMyEvent> {
+    fn __emit__(&self) {
+        let e = self.borrow();
+
+        emit!(MyEvent {
+            nums: e
+                .nums
+                .clone()
+                .borrow()
+                .clone()
+                .into_iter()
+                .map(|element| element)
+                .collect()
+        })
+    }
+}
+
+impl Loadable for MyEvent {
+    type Loaded = LoadedMyEvent;
+
+    fn load(stored: Self) -> Self::Loaded {
+        Self::Loaded {
+            nums: Mutable::new(stored.nums.into_iter().map(|element| element).collect()),
+        }
+    }
+
+    fn store(loaded: Self::Loaded) -> Self {
+        Self {
+            nums: loaded
+                .nums
+                .clone()
+                .borrow()
+                .clone()
+                .into_iter()
+                .map(|element| element)
+                .collect(),
+        }
+    }
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct Nested {
+    pub deep: Deep,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoadedNested {
+    pub deep: Mutable<Loaded!(Deep)>,
+}
+
+impl Mutable<LoadedNested> {
+    pub fn __init__(&self, mut num: i32) -> () {
+        assign!(
+            self.borrow_mut().deep,
+            <Loaded!(Deep)>::__new__(num.clone())
+        );
+    }
+
+    pub fn reset(&self) -> () {
+        assign!(self.borrow_mut().deep, <Loaded!(Deep)>::__new__(0));
+    }
+}
+
+impl LoadedNested {
+    pub fn __new__(num: i32) -> Mutable<Self> {
+        let obj = Mutable::new(LoadedNested::default());
+
+        obj.__init__(num);
+
+        return obj;
+    }
+}
+
+impl Loadable for Nested {
+    type Loaded = LoadedNested;
+
+    fn load(stored: Self) -> Self::Loaded {
+        Self::Loaded {
+            deep: Mutable::new(Deep::load(stored.deep)),
+        }
+    }
+
+    fn store(loaded: Self::Loaded) -> Self {
+        Self {
+            deep: Deep::store(loaded.deep.clone().borrow().clone()),
+        }
+    }
+}
+
+pub fn init_handler<'info>(
+    mut signer: SeahorseSigner<'info, '_>,
+    mut data: Empty<Mutable<LoadedData<'info, '_>>>,
+) -> () {
+    let mut init_data = data.account.clone();
+
+    assign!(init_data.borrow_mut().int_list, Mutable::new(vec![1, 2]));
+
+    assign!(
+        init_data.borrow_mut().int_list_2d,
+        Mutable::new(vec![Mutable::new(vec![3, 4]), Mutable::new(vec![5, 6])])
+    );
+
+    assign!(init_data.borrow_mut().string, "Hello".to_string());
+
+    assign!(init_data.borrow_mut().nested, <Loaded!(Nested)>::__new__(7));
+
+    assign!(
+        init_data.borrow_mut().nested_list,
+        Mutable::new(vec![
+            <Loaded!(Nested)>::__new__(8),
+            <Loaded!(Nested)>::__new__(9)
+        ])
+    );
+
+    assign!(
+        init_data.borrow_mut().more_data,
+        <Loaded!(MoreData)>::__new__(10)
+    );
+}
+
+pub fn test_stored_mutables_handler<'info>(
+    mut signer: SeahorseSigner<'info, '_>,
+    mut data: Mutable<LoadedData<'info, '_>>,
+) -> () {
+    assign!(
+        (*(*data
+            .borrow_mut()
+            .array_2d
+            .borrow_mut()
+            .index_wrapped_mut(0.into()))
+        .borrow_mut()
+        .index_wrapped_mut(0.into())),
+        1
+    );
+
+    data.borrow().int_list.borrow_mut().push(0);
+
+    assign!(
+        (*(*data
+            .borrow_mut()
+            .int_list_2d
+            .borrow_mut()
+            .index_wrapped_mut(0.into()))
+        .borrow_mut()
+        .index_wrapped_mut((-1).into())),
+        0
+    );
+
+    assign!(
+        data.borrow_mut().string,
+        data.borrow().string.clone() + &" World".to_string()
+    );
+
+    data.borrow().nested.reset();
+
+    (*data.borrow().nested_list.borrow().index_wrapped(0.into())).reset();
+
+    data.borrow()
+        .nested_list
+        .borrow_mut()
+        .push(<Loaded!(Nested)>::__new__(10));
+
+    assign!(data.borrow_mut().flag, Flag::ON);
+
+    assign!(
+        data.borrow_mut().more_data,
+        <Loaded!(MoreData)>::__new__(11)
+    );
+}
+
+// ===== dot/util/mod.rs =====
+
+pub mod more_data;
+
+// ===== dot/util/more_data.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{id, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone, Debug)]
+pub struct MoreData {
+    pub num: i32,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct LoadedMoreData {
+    pub num: i32,
+}
+
+impl Mutable<LoadedMoreData> {
+    pub fn __init__(&self, mut num: i32) -> () {
+        assign!(self.borrow_mut().num, num);
+    }
+}
+
+impl LoadedMoreData {
+    pub fn __new__(num: i32) -> Mutable<Self> {
+        let obj = Mutable::new(LoadedMoreData::default());
+
+        obj.__init__(num);
+
+        return obj;
+    }
+}
+
+impl Loadable for MoreData {
+    type Loaded = LoadedMoreData;
+
+    fn load(stored: Self) -> Self::Loaded {
+        Self::Loaded { num: stored.num }
+    }
+
+    fn store(loaded: Self::Loaded) -> Self {
+        Self { num: loaded.num }
+    }
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+pub mod seahorse_util {
+    use super::*;
+
+    #[cfg(feature = "pyth-sdk-solana")]
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Deref, Index, IndexMut},
+    };
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    pub trait IndexWrapped {
+        type Output;
+
+        fn index_wrapped(&self, index: i128) -> &Self::Output;
+    }
+
+    pub trait IndexWrappedMut: IndexWrapped {
+        fn index_wrapped_mut(&mut self, index: i128) -> &mut <Self as IndexWrapped>::Output;
+    }
+
+    impl<T> IndexWrapped for Vec<T> {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += self.len() as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T> IndexWrappedMut for Vec<T> {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += self.len() as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrapped for [T; N] {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrappedMut for [T; N] {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    pub trait Loadable {
+        type Loaded;
+
+        fn load(stored: Self) -> Self::Loaded;
+
+        fn store(loaded: Self::Loaded) -> Self;
+    }
+
+    macro_rules! Loaded {
+        ($ name : ty) => {
+            <$name as Loadable>::Loaded
+        };
+    }
+
+    pub(crate) use Loaded;
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
+}
+
+#[program]
+mod stored_mutables {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    pub struct Init<'info> {
+        #[account(mut)]
+        pub signer: Signer<'info>,
+        # [account (init , space = std :: mem :: size_of :: < dot :: program :: Data > () + 8 + (1024 as usize) , payer = signer , seeds = [signer . key () . as_ref ()] , bump)]
+        pub data: Box<Account<'info, dot::program::Data>>,
+        pub rent: Sysvar<'info, Rent>,
+        pub system_program: Program<'info, System>,
+    }
+
+    pub fn init(ctx: Context<Init>) -> Result<()> {
+        let mut programs = HashMap::new();
+
+        programs.insert(
+            "system_program",
+            ctx.accounts.system_program.to_account_info(),
+        );
+
+        let programs_map = ProgramsMap(programs);
+        let signer = SeahorseSigner {
+            account: &ctx.accounts.signer,
+            programs: &programs_map,
+        };
+
+        let data = Empty {
+            account: dot::program::Data::load(&mut ctx.accounts.data, &programs_map),
+            bump: ctx.bumps.get("data").map(|bump| *bump),
+        };
+
+        init_handler(signer.clone(), data.clone());
+
+        dot::program::Data::store(data.account);
+
+        return Ok(());
+    }
+
+    #[derive(Accounts)]
+    pub struct TestStoredMutables<'info> {
+        #[account(mut)]
+        pub signer: Signer<'info>,
+        #[account(mut)]
+        pub data: Box<Account<'info, dot::program::Data>>,
+    }
+
+    pub fn test_stored_mutables(ctx: Context<TestStoredMutables>) -> Result<()> {
+        let mut programs = HashMap::new();
+        let programs_map = ProgramsMap(programs);
+        let signer = SeahorseSigner {
+            account: &ctx.accounts.signer,
+            programs: &programs_map,
+        };
+
+        let data = dot::program::Data::load(&mut ctx.accounts.data, &programs_map);
+
+        test_stored_mutables_handler(signer.clone(), data.clone());
+
+        dot::program::Data::store(data);
+
+        return Ok(());
+    }
+}
+


### PR DESCRIPTION
Adds the ability to define account classes that store arbitrary data types, including:
- Lists of things (`List[T]`)
- Arrays of anything (including nested arrays - `Array[Array[T, M], N]`)
- User-defined classes (including classes that store any other types)

This is going to be a big change to the code gen, so it necessarily won't work with any of the current tests. I'll make sure to create a new test for all of the more complex features and use them in a real program so that we can be reasonably sure that this won't break existing code.

Closes #33 
Closes #59
Closes #64 