### PR TITLE
Make lib feature-aware and conditionally import Pyth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pyth compile error on latest version (#91)
 - Bug that prevented lists from being used in events
 - Bug that prevented users from importing accounts from other files
+- Conditionally generate Pyth import (#93)
 
 ## [0.2.7]
 

--- a/examples/pyth.py
+++ b/examples/pyth.py
@@ -1,0 +1,12 @@
+from seahorse.prelude import *
+from seahorse.pyth import *
+
+declare_id('EkY7qZD2RCr1LpUzADJkzbjGaWfbvGYB9eJe7DYCgGF8')
+
+
+@instruction
+def use_sol_usd_price(price_account: PriceAccount):
+    price_feed = price_account.validate_price_feed('devnet-SOL/USD')
+    price = price_feed.get_price()
+    price = price.num()
+    print(price)

--- a/tests/compiled-examples/calculator.rs
+++ b/tests/compiled-examples/calculator.rs
@@ -156,9 +156,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,

--- a/tests/compiled-examples/constants.rs
+++ b/tests/compiled-examples/constants.rs
@@ -51,9 +51,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,

--- a/tests/compiled-examples/event.rs
+++ b/tests/compiled-examples/event.rs
@@ -97,9 +97,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,

--- a/tests/compiled-examples/fizzbuzz.rs
+++ b/tests/compiled-examples/fizzbuzz.rs
@@ -106,9 +106,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,

--- a/tests/compiled-examples/hello.rs
+++ b/tests/compiled-examples/hello.rs
@@ -110,9 +110,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,

--- a/tests/compiled-examples/pyth.rs
+++ b/tests/compiled-examples/pyth.rs
@@ -1,0 +1,286 @@
+// ===== dot/mod.rs =====
+
+pub mod program;
+
+// ===== dot/program.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+use crate::{id, seahorse_util::*};
+use anchor_lang::{prelude::*, solana_program};
+use anchor_spl::token::{self, Mint, Token, TokenAccount};
+use std::{cell::RefCell, rc::Rc};
+
+pub fn use_sol_usd_price_handler<'info>(mut price_account: UncheckedAccount<'info>) -> () {
+    let mut price_feed = {
+        if price_account.key()
+            != Pubkey::new_from_array([
+                254u8, 101u8, 15u8, 3u8, 103u8, 212u8, 167u8, 239u8, 152u8, 21u8, 165u8, 147u8,
+                234u8, 21u8, 211u8, 101u8, 147u8, 240u8, 100u8, 58u8, 170u8, 240u8, 20u8, 155u8,
+                176u8, 75u8, 230u8, 122u8, 184u8, 81u8, 222u8, 205u8,
+            ])
+        {
+            panic!("Pyth PriceAccount validation failed: expected devnet-SOL/USD")
+        }
+
+        load_price_feed_from_account_info(&price_account).unwrap()
+    };
+
+    let mut price = price_feed.get_price_unchecked();
+    let mut price = {
+        let price = price;
+
+        (price.price as f64) * 10f64.powf(price.expo as f64)
+    };
+
+    solana_program::msg!("{}", price);
+}
+
+// ===== lib.rs =====
+
+#![allow(unused_imports)]
+#![allow(unused_variables)]
+#![allow(unused_mut)]
+
+pub mod dot;
+
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::{self, AssociatedToken},
+    token::{self, Mint, Token, TokenAccount},
+};
+
+use dot::program::*;
+use std::{cell::RefCell, rc::Rc};
+
+declare_id!("EkY7qZD2RCr1LpUzADJkzbjGaWfbvGYB9eJe7DYCgGF8");
+
+pub mod seahorse_util {
+    use super::*;
+
+    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
+    use std::{
+        collections::HashMap,
+        fmt::Debug,
+        ops::{Deref, Index, IndexMut},
+    };
+
+    pub struct Mutable<T>(Rc<RefCell<T>>);
+
+    impl<T> Mutable<T> {
+        pub fn new(obj: T) -> Self {
+            Self(Rc::new(RefCell::new(obj)))
+        }
+    }
+
+    impl<T> Clone for Mutable<T> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<T> Deref for Mutable<T> {
+        type Target = Rc<RefCell<T>>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<T: Debug> Debug for Mutable<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+
+    impl<T: Default> Default for Mutable<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
+    pub trait IndexWrapped {
+        type Output;
+
+        fn index_wrapped(&self, index: i128) -> &Self::Output;
+    }
+
+    pub trait IndexWrappedMut: IndexWrapped {
+        fn index_wrapped_mut(&mut self, index: i128) -> &mut <Self as IndexWrapped>::Output;
+    }
+
+    impl<T> IndexWrapped for Vec<T> {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += self.len() as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T> IndexWrappedMut for Vec<T> {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += self.len() as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrapped for [T; N] {
+        type Output = T;
+
+        fn index_wrapped(&self, mut index: i128) -> &Self::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index(index)
+        }
+    }
+
+    impl<T, const N: usize> IndexWrappedMut for [T; N] {
+        fn index_wrapped_mut(&mut self, mut index: i128) -> &mut <Self as IndexWrapped>::Output {
+            if index < 0 {
+                index += N as i128;
+            }
+
+            let index: usize = index.try_into().unwrap();
+
+            self.index_mut(index)
+        }
+    }
+
+    #[derive(Clone)]
+    pub struct Empty<T: Clone> {
+        pub account: T,
+        pub bump: Option<u8>,
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct ProgramsMap<'info>(pub HashMap<&'static str, AccountInfo<'info>>);
+
+    impl<'info> ProgramsMap<'info> {
+        pub fn get(&self, name: &'static str) -> AccountInfo<'info> {
+            self.0.get(name).unwrap().clone()
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    pub struct WithPrograms<'info, 'entrypoint, A> {
+        pub account: &'entrypoint A,
+        pub programs: &'entrypoint ProgramsMap<'info>,
+    }
+
+    impl<'info, 'entrypoint, A> Deref for WithPrograms<'info, 'entrypoint, A> {
+        type Target = A;
+
+        fn deref(&self) -> &Self::Target {
+            &self.account
+        }
+    }
+
+    pub type SeahorseAccount<'info, 'entrypoint, A> =
+        WithPrograms<'info, 'entrypoint, Box<Account<'info, A>>>;
+
+    pub type SeahorseSigner<'info, 'entrypoint> = WithPrograms<'info, 'entrypoint, Signer<'info>>;
+
+    #[derive(Clone, Debug)]
+    pub struct CpiAccount<'info> {
+        #[doc = "CHECK: CpiAccounts temporarily store AccountInfos."]
+        pub account_info: AccountInfo<'info>,
+        pub is_writable: bool,
+        pub is_signer: bool,
+        pub seeds: Option<Vec<Vec<u8>>>,
+    }
+
+    #[macro_export]
+    macro_rules! seahorse_const {
+        ($ name : ident , $ value : expr) => {
+            macro_rules! $name {
+                () => {
+                    $value
+                };
+            }
+
+            pub(crate) use $name;
+        };
+    }
+
+    pub trait Loadable {
+        type Loaded;
+
+        fn load(stored: Self) -> Self::Loaded;
+
+        fn store(loaded: Self::Loaded) -> Self;
+    }
+
+    macro_rules! Loaded {
+        ($ name : ty) => {
+            <$name as Loadable>::Loaded
+        };
+    }
+
+    pub(crate) use Loaded;
+
+    #[macro_export]
+    macro_rules! assign {
+        ($ lval : expr , $ rval : expr) => {{
+            let temp = $rval;
+
+            $lval = temp;
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! index_assign {
+        ($ lval : expr , $ idx : expr , $ rval : expr) => {
+            let temp_rval = $rval;
+            let temp_idx = $idx;
+
+            $lval[temp_idx] = temp_rval;
+        };
+    }
+
+    pub(crate) use assign;
+
+    pub(crate) use index_assign;
+
+    pub(crate) use seahorse_const;
+}
+
+#[program]
+mod pyth {
+    use super::*;
+    use seahorse_util::*;
+    use std::collections::HashMap;
+
+    #[derive(Accounts)]
+    pub struct UseSolUsdPrice<'info> {
+        #[account()]
+        #[doc = "CHECK: This account is unchecked."]
+        pub price_account: UncheckedAccount<'info>,
+    }
+
+    pub fn use_sol_usd_price(ctx: Context<UseSolUsdPrice>) -> Result<()> {
+        let mut programs = HashMap::new();
+        let programs_map = ProgramsMap(programs);
+        let price_account = &ctx.accounts.price_account.clone();
+
+        use_sol_usd_price_handler(price_account.clone());
+
+        return Ok(());
+    }
+}
+

--- a/tests/compiled-examples/stored_mutables.rs
+++ b/tests/compiled-examples/stored_mutables.rs
@@ -472,9 +472,6 @@ declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,

--- a/tests/compiled-test-cases/account_key.rs
+++ b/tests/compiled-test-cases/account_key.rs
@@ -115,9 +115,6 @@ declare_id!("4SEMJzX6o2YQNws7yrsfUdjJCR4B5Z3GyR2Pj7UgzDy2");
 
 pub mod seahorse_util {
     use super::*;
-
-    #[cfg(feature = "pyth-sdk-solana")]
-    pub use pyth_sdk_solana::{load_price_feed_from_account_info, PriceFeed};
     use std::{
         collections::HashMap,
         fmt::Debug,


### PR DESCRIPTION
This allows environments like Playground to know which dependencies are required without being aware of feature flags

We still use an optional feature + cargo feature flag for the dependency when running locally

The result is Seahorse 🤝 Pyth 🤝 Playground
<img width="1432" alt="Screenshot 2023-02-23 at 19 17 53" src="https://user-images.githubusercontent.com/1711350/220996533-d4a45189-545d-42df-a7e1-387dfe622bfe.png">

Closes: #75 