### PR TITLE
fix: seahorse init failing due to old incompatible pyth-sdk-solana

### DIFF
--- a/src/bin/cli/init.rs
+++ b/src/bin/cli/init.rs
@@ -206,10 +206,11 @@ pub fn init(args: InitArgs) -> Result<(), Box<dyn Error>> {
             cargo["dependencies"]["anchor-lang"] = anchor_version.clone();
             cargo["dependencies"]["anchor-spl"] = anchor_version;
 
+            // Add pyth-sdk-solana as a dependency
             let mut pyth = InlineTable::new();
             pyth.insert(
                 "version",
-                Value::String(Formatted::new("0.7.1".to_string())),
+                Value::String(Formatted::new("0.9.0".to_string())),
             );
             pyth.insert("optional", Value::Boolean(Formatted::new(true)));
             cargo["dependencies"]["pyth-sdk-solana"] = Item::Value(Value::InlineTable(pyth));


### PR DESCRIPTION
As of 2024 01 22, `seahorse init` would fail with:

```
% seahorse build
✗ Compiling calculator... (note: if this is your first time building, it might take a few minutes)
Error: anchor build -p calculator failed:

This is most likely a bug in the Seahorse compiler!

If you want to help the project, you can report this:
  - on the Seahorse Discord (http://discord.gg/4sFzH5pus8)
  - or as a Github issue (https://github.com/ameliatastic/seahorse-lang/issues).

Thanks!

[2024-01-22T17:55:01.097237000Z ERROR cargo_build_sbf] Failed to obtain package metadata: `cargo metadata` exited with an error:     Updating crates.io index
    error: failed to select a version for `solana-program`.
        ... required by package `spl-token-2022 v0.9.0`
        ... which satisfies dependency `spl-token-2022 = "^0.9"` of package `anchor-spl v0.29.0`
        ... which satisfies dependency `anchor-spl = "^0.29.0"` of package `calculator v0.1.0 (/Users/mikemaccana/Code/solana/course-solutions/calculator/programs/calculator)`
    versions that meet the requirements `^1.16.13` are: 1.17.17, 1.17.16, 1.17.15, 1.17.14, 1.17.13, 1.17.12, 1.17.11, 1.17.10, 1.17.9, 1.17.8, 1.17.7, 1.17.6, 1.17.5, 1.17.4, 1.17.3, 1.17.2, 1.17.1, 1.17.0, 1.16.27, 1.16.25, 1.16.24, 1.16.23, 1.16.22, 1.16.21, 1.16.20, 1.16.19, 1.16.18, 1.16.17, 1.16.16, 1.16.15, 1.16.14, 1.16.13

    all possible versions conflict with previously selected packages.

      previously selected package `solana-program v1.9.0`
        ... which satisfies dependency `solana-program = ">=1.9, <1.15"` of package `pyth-sdk-solana v0.7.0`
        ... which satisfies dependency `pyth-sdk-solana = "^0.7.0"` of package `calculator v0.1.0 (/Users/mikemaccana/Code/solana/course-solutions/calculator/programs/calculator)`

    failed to select a version for `solana-program` which could resolve this conflict
```

I'm just getting started with Rust, but my understanding is the old `pyth-sdk-solana` wants an old `solana-program` which conflicts with the current release.

Bumping the dependency (in ./programs/programname/Cargo.toml) fixes it.

```
[dependencies]
anchor-lang = "0.29.0"
anchor-spl = "0.29.0"
pyth-sdk-solana = "0.9.0"
```

This PR should do it automatically so you don't need to do that   