### PR TITLE
fix: seahorse init failing due to outdated ahash error

### DIFF
--- a/src/bin/cli/init.rs
+++ b/src/bin/cli/init.rs
@@ -214,6 +214,14 @@ pub fn init(args: InitArgs) -> Result<(), Box<dyn Error>> {
             pyth.insert("optional", Value::Boolean(Formatted::new(true)));
             cargo["dependencies"]["pyth-sdk-solana"] = Item::Value(Value::InlineTable(pyth));
 
+            // Fix 'error[E0658]: use of unstable library feature 'build_hasher_simple_hash_one'
+            let mut ahash = InlineTable::new();
+            ahash.insert(
+                "version",
+                Value::String(Formatted::new("=0.8.4".to_string())),
+            );
+            cargo["dependencies"]["ahash"] = Item::Value(Value::InlineTable(ahash));
+
             File::create(&cargo_path)?.write_all(cargo.to_string().as_bytes())?;
 
             // Add Anchor seeds feature


### PR DESCRIPTION
As of 2024 01 22.`seahorse build` would fail with:

```
   Compiling ahash v0.7.7
   Compiling rustversion v1.0.14
error[E0658]: use of unstable library feature 'build_hasher_simple_hash_one'
   --> src/random_state.rs:463:5
    |
463 | /     fn hash_one<T: Hash>(&self, x: T) -> u64 {
464 | |         RandomState::hash_one(self, x)
465 | |     }
    | |_____^
    |
    = note: see issue #86161 <https://github.com/rust-lang/rust/issues/86161> for more information
    = help: add `#![feature(build_hasher_simple_hash_one)]` to the crate attributes to enable

For more information about this error, try `rustc --explain E0658`.
error: could not compile `ahash` due to previous error
warning: build failed, waiting for other jobs to finish...
```

Bumping `ahash` in `./programs/programname/Cargo.toml` fixes it. Eg:

```
[dependencies]
anchor-lang = "0.29.0"
anchor-spl = "0.29.0"
pyth-sdk-solana = "0.9.0"
ahash = "=0.8.4"
```

This PR should ensure that's done by default. Please review it carefully, I am just getting started with Rust.